### PR TITLE
backupccl: add BOS GO SDK to vendor for case #32626

### DIFF
--- a/github.com/baidubce/bce-sdk-go/LICENSE
+++ b/github.com/baidubce/bce-sdk-go/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/github.com/baidubce/bce-sdk-go/auth/credentials.go
+++ b/github.com/baidubce/bce-sdk-go/auth/credentials.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// credentials.go - the credentials data structure definition
+
+// Package auth implements the authorization functionality for BCE.
+// It use the BCE access key ID and secret access key with the specific sign algorithm to generate
+// the authorization string. It also supports the temporary authorization by the STS token.
+package auth
+
+import "errors"
+
+// BceCredentials define the data structure for authorization
+type BceCredentials struct {
+	AccessKeyId     string // access key id to the service
+	SecretAccessKey string // secret access key to the service
+	SessionToken    string // session token generate by the STS service
+}
+
+func (b *BceCredentials) String() string {
+	str := "ak: " + b.AccessKeyId + ", sk: " + b.SecretAccessKey
+	if len(b.SessionToken) != 0 {
+		return str + ", sessionToken: " + b.SessionToken
+	}
+	return str
+}
+
+func NewBceCredentials(ak, sk string) (*BceCredentials, error) {
+	if len(ak) == 0 {
+		return nil, errors.New("accessKeyId should not be empty")
+	}
+	if len(sk) == 0 {
+		return nil, errors.New("secretKey should not be empty")
+	}
+
+	return &BceCredentials{ak, sk, ""}, nil
+}
+
+func NewSessionBceCredentials(ak, sk, token string) (*BceCredentials, error) {
+	if len(token) == 0 {
+		return nil, errors.New("sessionToken should not be empty")
+	}
+
+	result, err := NewBceCredentials(ak, sk)
+	if err != nil {
+		return nil, err
+	}
+	result.SessionToken = token
+
+	return result, nil
+}

--- a/github.com/baidubce/bce-sdk-go/auth/signer.go
+++ b/github.com/baidubce/bce-sdk-go/auth/signer.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// signer.go - implement the specific sign algorithm of BCE V1 protocol
+
+package auth
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/baidubce/bce-sdk-go/http"
+	"github.com/baidubce/bce-sdk-go/util"
+	"github.com/baidubce/bce-sdk-go/util/log"
+)
+
+var (
+	BCE_AUTH_VERSION        = "bce-auth-v1"
+	SIGN_JOINER             = "\n"
+	SIGN_HEADER_JOINER      = ";"
+	DEFAULT_EXPIRE_SECONDS  = 1800
+	DEFAULT_HEADERS_TO_SIGN = map[string]struct{}{
+		strings.ToLower(http.HOST):           {},
+		strings.ToLower(http.CONTENT_LENGTH): {},
+		strings.ToLower(http.CONTENT_TYPE):   {},
+		strings.ToLower(http.CONTENT_MD5):    {},
+	}
+)
+
+// Signer abstracts the entity that implements the `Sign` method
+type Signer interface {
+	// Sign the given Request with the Credentials and SignOptions
+	Sign(*http.Request, *BceCredentials, *SignOptions)
+}
+
+// SignOptions defines the data structure used by Signer
+type SignOptions struct {
+	HeadersToSign map[string]struct{}
+	Timestamp     int64
+	ExpireSeconds int
+}
+
+func (opt *SignOptions) String() string {
+	return fmt.Sprintf(`SignOptions [
+        HeadersToSign=%s;
+        Timestamp=%d;
+        ExpireSeconds=%d
+    ]`, opt.HeadersToSign, opt.Timestamp, opt.ExpireSeconds)
+}
+
+// BceV1Signer implements the v1 sign algorithm
+type BceV1Signer struct{}
+
+// Sign - generate the authorization string from the BceCredentials and SignOptions
+//
+// PARAMS:
+//     - req: *http.Request for this sign
+//     - cred: *BceCredentials to access the serice
+//     - opt: *SignOptions for this sign algorithm
+func (b *BceV1Signer) Sign(req *http.Request, cred *BceCredentials, opt *SignOptions) {
+	if req == nil {
+		log.Fatal("request should not be null for sign")
+		return
+	}
+	if cred == nil {
+		log.Fatal("credentials should not be null for sign")
+		return
+	}
+
+	// Prepare parameters
+	accessKeyId := cred.AccessKeyId
+	secretAccessKey := cred.SecretAccessKey
+	signDate := util.FormatISO8601Date(util.NowUTCSeconds())
+	// Modify the sign time if it is not the default value but specified by client
+	if opt.Timestamp != 0 {
+		signDate = util.FormatISO8601Date(opt.Timestamp)
+	}
+
+	// Set security token if using session credentials
+	if len(cred.SessionToken) != 0 {
+		req.SetHeader(http.BCE_SECURITY_TOKEN, cred.SessionToken)
+	}
+
+	// Prepare the canonical request components
+	signKeyInfo := fmt.Sprintf("%s/%s/%s/%d",
+		BCE_AUTH_VERSION,
+		accessKeyId,
+		signDate,
+		opt.ExpireSeconds)
+	signKey := util.HmacSha256Hex(secretAccessKey, signKeyInfo)
+	canonicalUri := getCanonicalURIPath(req.Uri())
+	canonicalQueryString := getCanonicalQueryString(req.Params())
+	canonicalHeaders, signedHeadersArr := getCanonicalHeaders(req.Headers(), opt.HeadersToSign)
+
+	// Generate signed headers string
+	signedHeaders := ""
+	if len(signedHeadersArr) > 0 {
+		sort.Strings(signedHeadersArr)
+		signedHeaders = strings.Join(signedHeadersArr, SIGN_HEADER_JOINER)
+	}
+
+	// Generate signature
+	canonicalParts := []string{req.Method(), canonicalUri, canonicalQueryString, canonicalHeaders}
+	canonicalReq := strings.Join(canonicalParts, SIGN_JOINER)
+	log.Debug("CanonicalRequest data:\n" + canonicalReq)
+	signature := util.HmacSha256Hex(signKey, canonicalReq)
+
+	// Generate auth string and add to the reqeust header
+	authStr := signKeyInfo + "/" + signedHeaders + "/" + signature
+	log.Info("Authorization=" + authStr)
+
+	req.SetHeader(http.AUTHORIZATION, authStr)
+}
+
+func getCanonicalURIPath(path string) string {
+	if len(path) == 0 {
+		return "/"
+	}
+	canonical_path := path
+	if strings.HasPrefix(path, "/") {
+		canonical_path = path[1:]
+	}
+	canonical_path = util.UriEncode(canonical_path, false)
+	return "/" + canonical_path
+}
+
+func getCanonicalQueryString(params map[string]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+
+	result := make([]string, 0, len(params))
+	for k, v := range params {
+		if strings.ToLower(k) == strings.ToLower(http.AUTHORIZATION) {
+			continue
+		}
+		item := ""
+		if len(v) == 0 {
+			item = fmt.Sprintf("%s=", util.UriEncode(k, true))
+		} else {
+			item = fmt.Sprintf("%s=%s", util.UriEncode(k, true), util.UriEncode(v, true))
+		}
+		result = append(result, item)
+	}
+	sort.Strings(result)
+	return strings.Join(result, "&")
+}
+
+func getCanonicalHeaders(headers map[string]string,
+	headersToSign map[string]struct{}) (string, []string) {
+	canonicalHeaders := make([]string, 0, len(headers))
+	signHeaders := make([]string, 0, len(headersToSign))
+	for k, v := range headers {
+		headKey := strings.ToLower(k)
+		if headKey == strings.ToLower(http.AUTHORIZATION) {
+			continue
+		}
+		_, headExists := headersToSign[headKey]
+		if headExists ||
+			(strings.HasPrefix(headKey, http.BCE_PREFIX) &&
+				(headKey != http.BCE_REQUEST_ID)) {
+
+			headVal := strings.TrimSpace(v)
+			encoded := util.UriEncode(headKey, true) + ":" + util.UriEncode(headVal, true)
+			canonicalHeaders = append(canonicalHeaders, encoded)
+			signHeaders = append(signHeaders, headKey)
+		}
+	}
+	sort.Strings(canonicalHeaders)
+	sort.Strings(signHeaders)
+	return strings.Join(canonicalHeaders, SIGN_JOINER), signHeaders
+}

--- a/github.com/baidubce/bce-sdk-go/bce/client.go
+++ b/github.com/baidubce/bce-sdk-go/bce/client.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// client.go - definiton the BceClientConfiguration and BceClient structure
+
+// Package bce implements the infrastructure to access BCE services.
+//
+// - BceClient:
+//     It is the general client of BCE to access all services. It builds http request to access the
+//     services based on the given client configuration.
+//
+// - BceClientConfiguration:
+//     The client configuration data structure which contains endpoint, region, credentials, retry
+//     policy, sign options and so on. It supports most of the default value and user can also
+//     access or change the default with its public fields' name.
+//
+// - Error types:
+//     The error types when making request or receiving response to the BCE services contains two
+//     types: the BceClientError when making request to BCE services and the BceServiceError when
+//     recieving response from them.
+//
+// - BceRequest:
+//     The request instance stands for an request to access the BCE services.
+//
+// - BceResponse:
+//     The response instance stands for an response from the BCE services.
+package bce
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/baidubce/bce-sdk-go/auth"
+	"github.com/baidubce/bce-sdk-go/http"
+	"github.com/baidubce/bce-sdk-go/util"
+	"github.com/baidubce/bce-sdk-go/util/log"
+)
+
+// Client is the general interface which can perform sending request. Different service
+// will define its own client in case of specific extension.
+type Client interface {
+	SendRequest(*BceRequest, *BceResponse) error
+}
+
+// BceClient defines the general client to access the BCE services.
+type BceClient struct {
+	Config *BceClientConfiguration
+	Signer auth.Signer // the sign algorithm
+}
+
+// BuildHttpRequest - the helper method for the client to build http request
+//
+// PARAMS:
+//     - request: the input request object to be built
+func (c *BceClient) buildHttpRequest(request *BceRequest) {
+	// Construct the http request instance for the special fields
+	request.BuildHttpRequest()
+
+	// Set the client specific configurations
+	request.SetEndpoint(c.Config.Endpoint)
+	if request.Protocol() == "" {
+		request.SetProtocol(DEFAULT_PROTOCOL)
+	}
+	if len(c.Config.ProxyUrl) != 0 {
+		request.SetProxyUrl(c.Config.ProxyUrl)
+	}
+	request.SetTimeout(c.Config.ConnectionTimeoutInMillis / 1000)
+
+	// Set the BCE request headers
+	request.SetHeader(http.HOST, request.Host())
+	request.SetHeader(http.USER_AGENT, c.Config.UserAgent)
+	request.SetHeader(http.BCE_DATE, util.FormatISO8601Date(util.NowUTCSeconds()))
+
+	// Generate the auth string if needed
+	if c.Config.Credentials != nil {
+		c.Signer.Sign(&request.Request, c.Config.Credentials, c.Config.SignOption)
+	}
+}
+
+// SendRequest - the client performs sending the http request with retry policy and receive the
+// response from the BCE services.
+//
+// PARAMS:
+//     - req: the request object to be sent to the BCE service
+//     - resp: the response object to receive the content from BCE service
+// RETURNS:
+//     - error: nil if ok otherwise the specific error
+func (c *BceClient) SendRequest(req *BceRequest, resp *BceResponse) error {
+	// Return client error if it is not nil
+	if req.ClientError() != nil {
+		return req.ClientError()
+	}
+
+	// Build the http request and prepare to send
+	c.buildHttpRequest(req)
+	log.Infof("send http request: %v", req)
+
+	// Send request with the given retry policy
+	retries := 0
+	if req.Body() != nil {
+		defer req.Body().Close() // Manually close the ReadCloser body for retry
+	}
+	for {
+		// The request body should be temporarily saved if retry to send the http request
+		var retryBuf bytes.Buffer
+		var teeReader io.Reader
+		if req.Body() != nil {
+			teeReader = io.TeeReader(req.Body(), &retryBuf)
+			req.Request.SetBody(ioutil.NopCloser(teeReader))
+		}
+		httpResp, err := http.Execute(&req.Request)
+
+		if err != nil {
+			if c.Config.Retry.ShouldRetry(err, retries) {
+				delay_in_mills := c.Config.Retry.GetDelayBeforeNextRetryInMillis(err, retries)
+				time.Sleep(delay_in_mills)
+			} else {
+				return &BceClientError{
+					fmt.Sprintf("execute http request failed! Retried %d times, error: %v",
+						retries, err)}
+			}
+			retries++
+			log.Warnf("send request failed: %v, retry for %d time(s)", err, retries)
+			if req.Body() != nil {
+				ioutil.ReadAll(teeReader)
+				req.Request.SetBody(ioutil.NopCloser(&retryBuf))
+			}
+			continue
+		}
+		resp.SetHttpResponse(httpResp)
+		resp.ParseResponse()
+
+		log.Infof("receive http response: status: %s, debugId: %s, requestId: %s, elapsed: %v",
+			resp.StatusText(), resp.DebugId(), resp.RequestId(), resp.ElapsedTime())
+		for k, v := range resp.Headers() {
+			log.Debugf("%s=%s", k, v)
+		}
+		if resp.IsFail() {
+			err := resp.ServiceError()
+			if c.Config.Retry.ShouldRetry(err, retries) {
+				delay_in_mills := c.Config.Retry.GetDelayBeforeNextRetryInMillis(err, retries)
+				time.Sleep(delay_in_mills)
+			} else {
+				return err
+			}
+			retries++
+			log.Warnf("send request failed, retry for %d time(s)", retries)
+			if req.Body() != nil {
+				ioutil.ReadAll(teeReader)
+				req.Request.SetBody(ioutil.NopCloser(&retryBuf))
+			}
+			continue
+		}
+		return nil
+	}
+}
+
+func NewBceClient(conf *BceClientConfiguration, sign auth.Signer) *BceClient {
+	return &BceClient{conf, sign}
+}

--- a/github.com/baidubce/bce-sdk-go/bce/config.go
+++ b/github.com/baidubce/bce-sdk-go/bce/config.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// config.go - define the client configuration for BCE
+
+package bce
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+
+	"github.com/baidubce/bce-sdk-go/auth"
+)
+
+// Constants and default values for the package bce
+const (
+	SDK_VERSION                          = "0.9.3"
+	URI_PREFIX                           = "/" // now support uri without prefix "v1" so just set root path
+	DEFAULT_DOMAIN                       = "baidubce.com"
+	DEFAULT_PROTOCOL                     = "http"
+	DEFAULT_REGION                       = "bj"
+	DEFAULT_CONTENT_TYPE                 = "application/json;charset=utf-8"
+	DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS = 1200 * 1000
+)
+
+var (
+	DEFAULT_USER_AGENT   string
+	DEFAULT_RETRY_POLICY = NewBackOffRetryPolicy(3, 20000, 300)
+)
+
+func init() {
+	DEFAULT_USER_AGENT = "bce-sdk-go"
+	DEFAULT_USER_AGENT += "/" + SDK_VERSION
+	DEFAULT_USER_AGENT += "/" + runtime.Version()
+	DEFAULT_USER_AGENT += "/" + runtime.GOOS
+	DEFAULT_USER_AGENT += "/" + runtime.GOARCH
+}
+
+// BceClientConfiguration defines the config components structure.
+type BceClientConfiguration struct {
+	Endpoint                  string
+	ProxyUrl                  string
+	Region                    string
+	UserAgent                 string
+	Credentials               *auth.BceCredentials
+	SignOption                *auth.SignOptions
+	Retry                     RetryPolicy
+	ConnectionTimeoutInMillis int
+}
+
+func (c *BceClientConfiguration) String() string {
+	return fmt.Sprintf(`BceClientConfiguration [
+        Endpoint=%s;
+        ProxyUrl=%s;
+        Region=%s;
+        UserAgent=%s;
+        Credentials=%v;
+        SignOption=%v;
+        RetryPolicy=%v;
+        ConnectionTimeoutInMillis=%v
+    ]`, c.Endpoint, c.ProxyUrl, c.Region, c.UserAgent, c.Credentials,
+		c.SignOption, reflect.TypeOf(c.Retry).Name(), c.ConnectionTimeoutInMillis)
+}

--- a/github.com/baidubce/bce-sdk-go/bce/error.go
+++ b/github.com/baidubce/bce-sdk-go/bce/error.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// error.go - define the error types for BCE
+
+package bce
+
+const (
+	EACCESS_DENIED            = "AccessDenied"
+	EINAPPROPRIATE_JSON       = "InappropriateJSON"
+	EINTERNAL_ERROR           = "InternalError"
+	EINVALID_ACCESS_KEY_ID    = "InvalidAccessKeyId"
+	EINVALID_HTTP_AUTH_HEADER = "InvalidHTTPAuthHeader"
+	EINVALID_HTTP_REQUEST     = "InvalidHTTPRequest"
+	EINVALID_URI              = "InvalidURI"
+	EMALFORMED_JSON           = "MalformedJSON"
+	EINVALID_VERSION          = "InvalidVersion"
+	EOPT_IN_REQUIRED          = "OptInRequired"
+	EPRECONDITION_FAILED      = "PreconditionFailed"
+	EREQUEST_EXPIRED          = "RequestExpired"
+	ESIGNATURE_DOES_NOT_MATCH = "SignatureDoesNotMatch"
+)
+
+// BceError abstracts the error for BCE
+type BceError interface {
+	error
+}
+
+// BceClientError defines the error struct for the client when making request
+type BceClientError struct{ Message string }
+
+func (b *BceClientError) Error() string { return b.Message }
+
+func NewBceClientError(msg string) *BceClientError { return &BceClientError{msg} }
+
+// BceServiceError defines the error struct for the BCE service when receiving response
+type BceServiceError struct {
+	Code       string
+	Message    string
+	RequestId  string
+	StatusCode int
+}
+
+func (b *BceServiceError) Error() string {
+	ret := "[Code: " + b.Code
+	ret += "; Message: " + b.Message
+	ret += "; RequestId: " + b.RequestId + "]"
+	return ret
+}
+
+func NewBceServiceError(code, msg, reqId string, status int) *BceServiceError {
+	return &BceServiceError{code, msg, reqId, status}
+}

--- a/github.com/baidubce/bce-sdk-go/bce/request.go
+++ b/github.com/baidubce/bce-sdk-go/bce/request.go
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// request.go - defines the BCE servies request
+
+package bce
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/baidubce/bce-sdk-go/http"
+	"github.com/baidubce/bce-sdk-go/util"
+)
+
+// Body defines the data structure used in BCE request.
+// Every BCE request that sets the body field must set its content-length and content-md5 headers
+// to ensure the correctness of the body content forcely, and users can also set the content-sha256
+// header to strengthen the correctness with the "SetHeader" method.
+type Body struct {
+	stream     io.ReadCloser
+	size       int64
+	contentMD5 string
+}
+
+func (b *Body) Stream() io.ReadCloser { return b.stream }
+
+func (b *Body) SetStream(stream io.ReadCloser) { b.stream = stream }
+
+func (b *Body) Size() int64 { return b.size }
+
+func (b *Body) ContentMD5() string { return b.contentMD5 }
+
+// NewBodyFromBytes - build a Body object from the byte stream to be used in the http request, it
+// calculates the content-md5 of the byte stream and store the size as well as the stream.
+//
+// PARAMS:
+//     - stream: byte stream
+// RETURNS:
+//     - *Body: the return Body object
+//     - error: error if any specific error occurs
+func NewBodyFromBytes(stream []byte) (*Body, error) {
+	buf := bytes.NewBuffer(stream)
+	size := int64(buf.Len())
+	contentMD5, err := util.CalculateContentMD5(buf, size)
+	if err != nil {
+		return nil, err
+	}
+	buf = bytes.NewBuffer(stream)
+	return &Body{ioutil.NopCloser(buf), size, contentMD5}, nil
+}
+
+// NewBodyFromString - build a Body object from the string to be used in the http request, it
+// calculates the content-md5 of the byte stream and store the size as well as the stream.
+//
+// PARAMS:
+//     - str: the input string
+// RETURNS:
+//     - *Body: the return Body object
+//     - error: error if any specific error occurs
+func NewBodyFromString(str string) (*Body, error) {
+	buf := bytes.NewBufferString(str)
+	size := int64(len(str))
+	contentMD5, err := util.CalculateContentMD5(buf, size)
+	if err != nil {
+		return nil, err
+	}
+	buf = bytes.NewBufferString(str)
+	return &Body{ioutil.NopCloser(buf), size, contentMD5}, nil
+}
+
+// NewBodyFromFile - build a Body object from the given file name to be used in the http request,
+// it calculates the content-md5 of the byte stream and store the size as well as the stream.
+//
+// PARAMS:
+//     - fname: the given file name
+// RETURNS:
+//     - *Body: the return Body object
+//     - error: error if any specific error occurs
+func NewBodyFromFile(fname string) (*Body, error) {
+	file, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	fileInfo, infoErr := file.Stat()
+	if infoErr != nil {
+		return nil, infoErr
+	}
+	contentMD5, md5Err := util.CalculateContentMD5(file, fileInfo.Size())
+	if md5Err != nil {
+		return nil, md5Err
+	}
+	if _, err = file.Seek(0, 0); err != nil {
+		return nil, err
+	}
+	return &Body{file, fileInfo.Size(), contentMD5}, nil
+}
+
+// NewBodyFromSectionFile - build a Body object from the given file pointer with offset and size.
+// It calculates the content-md5 of the given content and store the size as well as the stream.
+//
+// PARAMS:
+//     - file: the input file pointer
+//     - off: offset of current section body
+//     - size: current section body size
+// RETURNS:
+//     - *Body: the return Body object
+//     - error: error if any specific error occurs
+func NewBodyFromSectionFile(file *os.File, off, size int64) (*Body, error) {
+	if _, err := file.Seek(off, 0); err != nil {
+		return nil, err
+	}
+	contentMD5, md5Err := util.CalculateContentMD5(file, size)
+	if md5Err != nil {
+		return nil, md5Err
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return nil, err
+	}
+	section := io.NewSectionReader(file, off, size)
+	return &Body{ioutil.NopCloser(section), size, contentMD5}, nil
+}
+
+// NewBodyFromSizedReader - build a Body object from the given reader with size.
+// It calculates the content-md5 of the given content and store the size as well as the stream.
+//
+// PARAMS:
+//     - r: the input reader
+//     - size: the size to be read from the input reader which must be <= reader size
+// RETURNS:
+//     - *Body: the return Body object
+//     - error: error if any specific error occurs
+func NewBodyFromSizedReader(r io.Reader, size int64) (*Body, error) {
+	var err error
+	var buf1, buf2 bytes.Buffer
+	tee := io.TeeReader(r, &buf1)
+	readerSize, err := io.Copy(&buf2, tee)
+	if err != nil {
+		return nil, err
+	}
+	if readerSize < size {
+		return nil, NewBceClientError("given size can't be bigger than the reader actual size")
+	}
+	contentMD5 := ""
+	if size >= 0 {
+		contentMD5, err = util.CalculateContentMD5(&buf1, size)
+	}
+	if err != nil {
+		return nil, err
+	}
+	stream := io.LimitReader(&buf2, size)
+	return &Body{ioutil.NopCloser(stream), size, contentMD5}, nil
+}
+
+// BceRequest defines the request structure for accessing BCE services
+type BceRequest struct {
+	http.Request
+	requestId   string
+	clientError *BceClientError
+}
+
+func (b *BceRequest) RequestId() string { return b.requestId }
+
+func (b *BceRequest) SetRequestId(val string) { b.requestId = val }
+
+func (b *BceRequest) ClientError() *BceClientError { return b.clientError }
+
+func (b *BceRequest) SetClientError(err *BceClientError) { b.clientError = err }
+
+func (b *BceRequest) SetBody(body *Body) { // override SetBody derived from http.Request
+	b.Request.SetBody(body.Stream())
+	b.SetLength(body.Size()) // set field of "net/http.Request.ContentLength"
+	if body.Size() > 0 {
+		b.SetHeader(http.CONTENT_MD5, body.ContentMD5())
+		b.SetHeader(http.CONTENT_LENGTH, fmt.Sprintf("%d", body.Size()))
+	}
+}
+
+func (b *BceRequest) BuildHttpRequest() {
+	// Only need to build the specific `requestId` field for BCE, other fields are same as the
+	// `http.Request` as well as its methods.
+	if len(b.requestId) == 0 {
+		// Construct the request ID with UUID
+		b.requestId = util.NewRequestId()
+	}
+	b.SetHeader(http.BCE_REQUEST_ID, b.requestId)
+}
+
+func (b *BceRequest) String() string {
+	requestIdStr := "requestId=" + b.requestId
+	if b.clientError != nil {
+		return requestIdStr + ", client error: " + b.ClientError().Error()
+	}
+	return requestIdStr + "\n" + b.Request.String()
+}

--- a/github.com/baidubce/bce-sdk-go/bce/response.go
+++ b/github.com/baidubce/bce-sdk-go/bce/response.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// response.go - defines the common BCE services response
+
+package bce
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/baidubce/bce-sdk-go/http"
+)
+
+// BceResponse defines the response structure for receiving BCE services response.
+type BceResponse struct {
+	statusCode   int
+	statusText   string
+	requestId    string
+	debugId      string
+	response     *http.Response
+	serviceError *BceServiceError
+}
+
+func (r *BceResponse) IsFail() bool {
+	return r.response.StatusCode() >= 400
+}
+
+func (r *BceResponse) StatusCode() int {
+	return r.statusCode
+}
+
+func (r *BceResponse) StatusText() string {
+	return r.statusText
+}
+
+func (r *BceResponse) RequestId() string {
+	return r.requestId
+}
+
+func (r *BceResponse) DebugId() string {
+	return r.debugId
+}
+
+func (r *BceResponse) Header(key string) string {
+	return r.response.GetHeader(key)
+}
+
+func (r *BceResponse) Headers() map[string]string {
+	return r.response.GetHeaders()
+}
+
+func (r *BceResponse) Body() io.ReadCloser {
+	return r.response.Body()
+}
+
+func (r *BceResponse) SetHttpResponse(response *http.Response) {
+	r.response = response
+}
+
+func (r *BceResponse) ElapsedTime() time.Duration {
+	return r.response.ElapsedTime()
+}
+
+func (r *BceResponse) ServiceError() *BceServiceError {
+	return r.serviceError
+}
+
+func (r *BceResponse) ParseResponse() {
+	r.statusCode = r.response.StatusCode()
+	r.statusText = r.response.StatusText()
+	r.requestId = r.response.GetHeader(http.BCE_REQUEST_ID)
+	r.debugId = r.response.GetHeader(http.BCE_DEBUG_ID)
+	if r.IsFail() {
+		r.serviceError = NewBceServiceError("", r.statusText, r.requestId, r.statusCode)
+
+		// First try to read the error `Code' and `Message' from body
+		rawBody, _ := ioutil.ReadAll(r.Body())
+		defer r.Body().Close()
+		if len(rawBody) != 0 {
+			jsonDecoder := json.NewDecoder(bytes.NewBuffer(rawBody))
+			if err := jsonDecoder.Decode(r.serviceError); err != nil {
+				r.serviceError = NewBceServiceError(
+					EMALFORMED_JSON,
+					"Service json error message decode failed",
+					r.requestId,
+					r.statusCode)
+			}
+			return
+		}
+
+		// Then guess the `Message' from by the return status code
+		switch r.statusCode {
+		case 400:
+			r.serviceError.Code = EINVALID_HTTP_REQUEST
+		case 403:
+			r.serviceError.Code = EACCESS_DENIED
+		case 412:
+			r.serviceError.Code = EPRECONDITION_FAILED
+		case 500:
+			r.serviceError.Code = EINTERNAL_ERROR
+		default:
+			words := strings.Split(r.statusText, " ")
+			r.serviceError.Code = strings.Join(words[1:], "")
+		}
+	}
+}
+
+func (r *BceResponse) ParseJsonBody(result interface{}) error {
+	defer r.Body().Close()
+	jsonDecoder := json.NewDecoder(r.Body())
+	return jsonDecoder.Decode(result)
+}

--- a/github.com/baidubce/bce-sdk-go/bce/retry.go
+++ b/github.com/baidubce/bce-sdk-go/bce/retry.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// retry.go - define the retry policy when making requests to BCE services
+
+package bce
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/baidubce/bce-sdk-go/util/log"
+)
+
+// RetryPolicy defines the two methods to retry for sending request.
+type RetryPolicy interface {
+	ShouldRetry(BceError, int) bool
+	GetDelayBeforeNextRetryInMillis(BceError, int) time.Duration
+}
+
+// NoRetryPolicy just does not retry.
+type NoRetryPolicy struct{}
+
+func (_ *NoRetryPolicy) ShouldRetry(err BceError, attempts int) bool {
+	return false
+}
+
+func (_ *NoRetryPolicy) GetDelayBeforeNextRetryInMillis(
+	err BceError, attempts int) time.Duration {
+	return 0 * time.Millisecond
+}
+
+func NewNoRetryPolicy() *NoRetryPolicy {
+	return &NoRetryPolicy{}
+}
+
+// BackOffRetryPolicy implements a policy that retries with exponential back-off strategy.
+// This policy will keep retrying until the maximum number of retries is reached. The delay time
+// will be a fixed interval for the first time then 2 * interval for the second, 4 * internal for
+// the third, and so on.
+// In general, the delay time will be 2^number_of_retries_attempted*interval. When a maximum of
+// delay time is specified, the delay time will never exceed this limit.
+type BackOffRetryPolicy struct {
+	maxErrorRetry        int
+	maxDelayInMillis     int64
+	baseIntervalInMillis int64
+}
+
+func (b *BackOffRetryPolicy) ShouldRetry(err BceError, attempts int) bool {
+	// Do not retry any more when retry the max times
+	if attempts >= b.maxErrorRetry {
+		return false
+	}
+
+	// Always retry on IO error
+	if _, ok := err.(net.Error); ok {
+		return true
+	}
+
+	// Only retry on a service error
+	if realErr, ok := err.(*BceServiceError); ok {
+		switch realErr.StatusCode {
+		case http.StatusInternalServerError:
+			log.Warn("retry for internal server error(500)")
+			return true
+		case http.StatusBadGateway:
+			log.Warn("retry for bad gateway(502)")
+			return true
+		case http.StatusServiceUnavailable:
+			log.Warn("retry for service unavailable(503)")
+			return true
+		case http.StatusBadRequest:
+			if realErr.Code != "Http400" {
+				return false
+			}
+			log.Warn("retry for bad request(400)")
+			return true
+		}
+
+		if realErr.Code == EREQUEST_EXPIRED {
+			log.Warn("retry for request expired")
+			return true
+		}
+	}
+	return false
+}
+
+func (b *BackOffRetryPolicy) GetDelayBeforeNextRetryInMillis(
+	err BceError, attempts int) time.Duration {
+	if attempts < 0 {
+		return 0 * time.Millisecond
+	}
+	delayInMillis := (1 << uint64(attempts)) * b.baseIntervalInMillis
+	if delayInMillis > b.maxDelayInMillis {
+		return time.Duration(b.maxDelayInMillis) * time.Millisecond
+	}
+	return time.Duration(delayInMillis) * time.Millisecond
+}
+
+func NewBackOffRetryPolicy(maxRetry int, maxDelay, base int64) *BackOffRetryPolicy {
+	return &BackOffRetryPolicy{maxRetry, maxDelay, base}
+}

--- a/github.com/baidubce/bce-sdk-go/http/client.go
+++ b/github.com/baidubce/bce-sdk-go/http/client.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// client.go - define the execute function to send http request and get response
+
+// Package http defines the structure of request and response which used to access the BCE services
+// as well as the http constant headers and and methods. And finally implement the `Execute` funct-
+// ion to do the work.
+package http
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	defaultMaxIdleConnsPerHost   = 500
+	defaultResponseHeaderTimeout = 60 * time.Second
+	defaultDialTimeout           = 30 * time.Second
+	defaultSmallInterval         = 600 * time.Second
+	defaultLargeInterval         = 1200 * time.Second
+)
+
+// The httpClient is the global variable to send the request and get response
+// for reuse and the Client provided by the Go standard library is thread safe.
+var (
+	httpClient *http.Client
+	transport  *http.Transport
+)
+
+type timeoutConn struct {
+	conn          net.Conn
+	smallInterval time.Duration
+	largeInterval time.Duration
+}
+
+func (c *timeoutConn) Read(b []byte) (n int, err error) {
+	c.SetReadDeadline(time.Now().Add(c.smallInterval))
+	n, err = c.conn.Read(b)
+	c.SetReadDeadline(time.Now().Add(c.largeInterval))
+	return n, err
+}
+func (c *timeoutConn) Write(b []byte) (n int, err error) {
+	c.SetWriteDeadline(time.Now().Add(c.smallInterval))
+	n, err = c.conn.Write(b)
+	c.SetWriteDeadline(time.Now().Add(c.largeInterval))
+	return n, err
+}
+func (c *timeoutConn) Close() error                       { return c.conn.Close() }
+func (c *timeoutConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
+func (c *timeoutConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
+func (c *timeoutConn) SetDeadline(t time.Time) error      { return c.conn.SetDeadline(t) }
+func (c *timeoutConn) SetReadDeadline(t time.Time) error  { return c.conn.SetReadDeadline(t) }
+func (c *timeoutConn) SetWriteDeadline(t time.Time) error { return c.conn.SetWriteDeadline(t) }
+
+func init() {
+	httpClient = &http.Client{}
+	transport = &http.Transport{
+		MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost,
+		ResponseHeaderTimeout: defaultResponseHeaderTimeout,
+		Dial: func(network, address string) (net.Conn, error) {
+			conn, err := net.DialTimeout(network, address, defaultDialTimeout)
+			if err != nil {
+				return nil, err
+			}
+			tc := &timeoutConn{conn, defaultSmallInterval, defaultLargeInterval}
+			tc.SetReadDeadline(time.Now().Add(defaultLargeInterval))
+			return tc, nil
+		},
+	}
+	httpClient.Transport = transport
+}
+
+// Execute - do the http requset and get the response
+//
+// PARAMS:
+//     - request: the http request instance to be sent
+// RETURNS:
+//     - response: the http response returned from the server
+//     - error: nil if ok otherwise the specific error
+func Execute(request *Request) (*Response, error) {
+	// Build the request object for the current requesting
+	httpRequest := &http.Request{
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+
+	// Set the connection timeout for current request
+	httpClient.Timeout = time.Duration(request.Timeout()) * time.Second
+
+	// Set the request method
+	httpRequest.Method = request.Method()
+
+	// Set the request url
+	internalUrl := &url.URL{
+		Scheme:   request.Protocol(),
+		Host:     request.Host(),
+		Path:     request.Uri(),
+		RawQuery: request.QueryString()}
+	httpRequest.URL = internalUrl
+
+	// Set the request headers
+	internalHeader := make(http.Header)
+	for k, v := range request.Headers() {
+		val := make([]string, 0, 1)
+		val = append(val, v)
+		internalHeader[k] = val
+	}
+	httpRequest.Header = internalHeader
+
+	// Set the reqeust body and content length if needed
+	// Variable body's type is `*BodyStream`. If its value is nil, the `Body` field must be
+	// explicitly assigned `nil` value, otherwise nil pointer dereference will arise.
+	body := request.Body()
+	if body != nil && request.Length() != 0 { // body != nil and length == 0 regards unknown
+		httpRequest.Body = body
+		httpRequest.ContentLength = request.Length()
+	}
+
+	// Set the proxy setting if needed
+	if len(request.ProxyUrl()) != 0 {
+		transport.Proxy = func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(request.ProxyUrl())
+		}
+	}
+
+	// Perform the http request and get response
+	// It needs to explicitly close the keep-alive connections when error occurs for the request
+	// that may continue sending request's data subsequently.
+	start := time.Now()
+	httpResponse, err := httpClient.Do(httpRequest)
+	end := time.Now()
+	if err != nil {
+		transport.CloseIdleConnections()
+		return nil, err
+	}
+	if httpResponse.StatusCode >= 400 &&
+		(httpRequest.Method == PUT || httpRequest.Method == POST) {
+		transport.CloseIdleConnections()
+	}
+	response := &Response{httpResponse, end.Sub(start)}
+	return response, nil
+}

--- a/github.com/baidubce/bce-sdk-go/http/constants.go
+++ b/github.com/baidubce/bce-sdk-go/http/constants.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// constants.go - defines constants of the BCE http package including headers and methods
+
+package http
+
+// Constants of the supported HTTP methods for BCE
+const (
+	GET    = "GET"
+	PUT    = "PUT"
+	POST   = "POST"
+	DELETE = "DELETE"
+	HEAD   = "HEAD"
+)
+
+// Constants of the HTTP headers for BCE
+const (
+	// Standard HTTP Headers
+	AUTHORIZATION       = "Authorization"
+	CACHE_CONTROL       = "Cache-Control"
+	CONTENT_DISPOSITION = "Content-Disposition"
+	CONTENT_ENCODING    = "Content-Encoding"
+	CONTENT_LANGUAGE    = "Content-Language"
+	CONTENT_LENGTH      = "Content-Length"
+	CONTENT_MD5         = "Content-Md5"
+	CONTENT_RANGE       = "Content-Range"
+	CONTENT_TYPE        = "Content-Type"
+	DATE                = "Date"
+	ETAG                = "Etag"
+	EXPIRES             = "Expires"
+	HOST                = "Host"
+	LAST_MODIFIED       = "Last-Modified"
+	LOCATION            = "Location"
+	RANGE               = "Range"
+	SERVER              = "Server"
+	TRANSFER_ENCODING   = "Transfer-Encoding"
+	USER_AGENT          = "User-Agent"
+
+	// BCE Common HTTP Headers
+	BCE_PREFIX               = "x-bce-"
+	BCE_ACL                  = "x-bce-acl"
+	BCE_GRANT_READ           = "x-bce-grant-read"
+	BCE_GRANT_FULL_CONTROL   = "x-bce-grant-full-control"
+	BCE_CONTENT_SHA256       = "x-bce-content-sha256"
+	BCE_REQUEST_ID           = "x-bce-request-id"
+	BCE_USER_METADATA_PREFIX = "x-bce-meta-"
+	BCE_SECURITY_TOKEN       = "x-bce-security-token"
+	BCE_DATE                 = "x-bce-date"
+
+	// BOS HTTP Headers
+	BCE_COPY_METADATA_DIRECTIVE         = "x-bce-metadata-directive"
+	BCE_COPY_SOURCE                     = "x-bce-copy-source"
+	BCE_COPY_SOURCE_IF_MATCH            = "x-bce-copy-source-if-match"
+	BCE_COPY_SOURCE_IF_MODIFIED_SINCE   = "x-bce-copy-source-if-modified-since"
+	BCE_COPY_SOURCE_IF_NONE_MATCH       = "x-bce-copy-source-if-none-match"
+	BCE_COPY_SOURCE_IF_UNMODIFIED_SINCE = "x-bce-copy-source-if-unmodified-since"
+	BCE_COPY_SOURCE_RANGE               = "x-bce-copy-source-range"
+	BCE_DEBUG_ID                        = "x-bce-debug-id"
+	BCE_OBJECT_TYPE                     = "x-bce-object-type"
+	BCE_NEXT_APPEND_OFFSET              = "x-bce-next-append-offset"
+	BCE_STORAGE_CLASS                   = "x-bce-storage-class"
+)

--- a/github.com/baidubce/bce-sdk-go/http/request.go
+++ b/github.com/baidubce/bce-sdk-go/http/request.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// request.go - the custom HTTP request for BCE
+
+package http
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/baidubce/bce-sdk-go/util"
+)
+
+// Reauest stands for the general http request structure to make request to the BCE services.
+type Request struct {
+	protocol string
+	host     string
+	port     int
+	method   string
+	uri      string
+	proxyUrl string
+	timeout  int
+	headers  map[string]string
+	params   map[string]string
+
+	// Optional body and length fields to set the body stream and content length
+	body   io.ReadCloser
+	length int64
+}
+
+func (r *Request) Protocol() string {
+	return r.protocol
+}
+
+func (r *Request) SetProtocol(protocol string) {
+	r.protocol = protocol
+}
+
+func (r *Request) Endpoint() string {
+	return r.protocol + "://" + r.host
+}
+
+func (r *Request) SetEndpoint(endpoint string) {
+	pos := strings.Index(endpoint, "://")
+	rest := endpoint
+	if pos != -1 {
+		r.protocol = endpoint[0:pos]
+		rest = endpoint[pos+3:]
+	} else {
+		r.protocol = "http"
+	}
+
+	r.SetHost(rest)
+}
+
+func (r *Request) Host() string {
+	return r.host
+}
+
+func (r *Request) SetHost(host string) {
+	r.host = host
+	pos := strings.Index(host, ":")
+	if pos != -1 {
+		p, e := strconv.Atoi(host[pos+1:])
+		if e == nil {
+			r.port = p
+		}
+	}
+
+	if r.port == 0 {
+		if r.protocol == "http" {
+			r.port = 80
+		} else if r.protocol == "https" {
+			r.port = 443
+		}
+	}
+}
+
+func (r *Request) Port() int {
+	return r.port
+}
+
+func (r *Request) SetPort(port int) {
+	// Port can be set by the endpoint or host, this method is rarely used.
+	r.port = port
+}
+
+func (r *Request) Headers() map[string]string {
+	return r.headers
+}
+
+func (r *Request) SetHeaders(headers map[string]string) {
+	r.headers = headers
+}
+
+func (r *Request) Header(key string) string {
+	if v, ok := r.headers[key]; ok {
+		return v
+	}
+	return ""
+}
+
+func (r *Request) SetHeader(key, value string) {
+	if r.headers == nil {
+		r.headers = make(map[string]string)
+	}
+	r.headers[key] = value
+}
+
+func (r *Request) Params() map[string]string {
+	return r.params
+}
+
+func (r *Request) SetParams(params map[string]string) {
+	r.params = params
+}
+
+func (r *Request) Param(key string) string {
+	if v, ok := r.params[key]; ok {
+		return v
+	}
+	return ""
+}
+
+func (r *Request) SetParam(key, value string) {
+	if r.params == nil {
+		r.params = make(map[string]string)
+	}
+	r.params[key] = value
+}
+
+func (r *Request) QueryString() string {
+	buf := make([]string, 0, len(r.params))
+	for k, v := range r.params {
+		buf = append(buf, util.UriEncode(k, true)+"="+util.UriEncode(v, true))
+	}
+	return strings.Join(buf, "&")
+}
+
+func (r *Request) Method() string {
+	return r.method
+}
+
+func (r *Request) SetMethod(method string) {
+	r.method = method
+}
+
+func (r *Request) Uri() string {
+	return r.uri
+}
+
+func (r *Request) SetUri(uri string) {
+	r.uri = uri
+}
+
+func (r *Request) ProxyUrl() string {
+	return r.proxyUrl
+}
+
+func (r *Request) SetProxyUrl(url string) {
+	r.proxyUrl = url
+}
+
+func (r *Request) Timeout() int {
+	return r.timeout
+}
+
+func (r *Request) SetTimeout(timeout int) {
+	r.timeout = timeout
+}
+
+func (r *Request) Body() io.ReadCloser {
+	return r.body
+}
+
+func (r *Request) SetBody(stream io.ReadCloser) {
+	r.body = stream
+}
+
+func (r *Request) Length() int64 {
+	return r.length
+}
+
+func (r *Request) SetLength(l int64) {
+	r.length = l
+}
+
+func (r *Request) GenerateUrl(addPort bool) string {
+	if addPort {
+		return fmt.Sprintf("%s://%s:%d%s?%s",
+			r.protocol, r.host, r.port, r.uri, r.QueryString())
+	} else {
+		return fmt.Sprintf("%s://%s%s?%s", r.protocol, r.host, r.uri, r.QueryString())
+	}
+}
+
+func (r *Request) String() string {
+	header := make([]string, 0, len(r.headers))
+	for k, v := range r.headers {
+		header = append(header, "\t"+k+"="+v)
+	}
+	return fmt.Sprintf("\t%s %s\n%v",
+		r.method, r.GenerateUrl(false), strings.Join(header, "\n"))
+}

--- a/github.com/baidubce/bce-sdk-go/http/response.go
+++ b/github.com/baidubce/bce-sdk-go/http/response.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// response.go - the custom HTTP response for BCE
+
+package http
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+// Response defines the general http response structure for accessing the BCE services.
+type Response struct {
+	httpResponse *http.Response // the standard libaray http.Response object
+	elapsedTime  time.Duration  // elapsed time just from sending request to receiving response
+}
+
+func (r *Response) StatusText() string {
+	return r.httpResponse.Status
+}
+
+func (r *Response) StatusCode() int {
+	return r.httpResponse.StatusCode
+}
+
+func (r *Response) Protocol() string {
+	return r.httpResponse.Proto
+}
+
+func (r *Response) HttpResponse() *http.Response {
+	return r.httpResponse
+}
+
+func (r *Response) SetHttpResponse(response *http.Response) {
+	r.httpResponse = response
+}
+
+func (r *Response) ElapsedTime() time.Duration {
+	return r.elapsedTime
+}
+
+func (r *Response) GetHeader(name string) string {
+	return r.httpResponse.Header.Get(name)
+}
+
+func (r *Response) GetHeaders() map[string]string {
+	header := r.httpResponse.Header
+	ret := make(map[string]string, len(header))
+	for k, v := range header {
+		ret[k] = v[0]
+	}
+	return ret
+}
+
+func (r *Response) ContentLength() int64 {
+	return r.httpResponse.ContentLength
+}
+
+func (r *Response) Body() io.ReadCloser {
+	return r.httpResponse.Body
+}

--- a/github.com/baidubce/bce-sdk-go/services/bos/api/bucket.go
+++ b/github.com/baidubce/bce-sdk-go/services/bos/api/bucket.go
@@ -1,0 +1,919 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// bucket.go - the bucket APIs definition supported by the BOS service
+
+// Package api defines all APIs supported by the BOS service of BCE.
+package api
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/http"
+)
+
+// ListBuckets - list all buckets of the account
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+// RETURNS:
+//     - *ListBucketsResult: the result bucket list structure
+//     - error: nil if ok otherwise the specific error
+func ListBuckets(cli bce.Client) (*ListBucketsResult, error) {
+	req := &bce.BceRequest{}
+	req.SetMethod(http.GET)
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &ListBucketsResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListObjects - list all objects of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - args: the optional arguments to list objects
+// RETURNS:
+//     - *ListObjectsResult: the result object list structure
+//     - error: nil if ok otherwise the specific error
+func ListObjects(cli bce.Client, bucket string,
+	args *ListObjectsArgs) (*ListObjectsResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+
+	// Optional arguments settings
+	if args != nil {
+		if len(args.Delimiter) != 0 {
+			req.SetParam("delimiter", args.Delimiter)
+		}
+		if len(args.Marker) != 0 {
+			req.SetParam("marker", args.Marker)
+		}
+		req.SetParam("maxKeys", strconv.Itoa(args.MaxKeys))
+		if len(args.Prefix) != 0 {
+			req.SetParam("prefix", args.Prefix)
+		}
+	}
+
+	// Send the request and get result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &ListObjectsResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// HeadBucket - test the given bucket existed and access authority
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if exists and have authority otherwise the specific error
+func HeadBucket(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.HEAD)
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// PutBucket - create a new bucket with the given name
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the new bucket name
+// RETURNS:
+//     - string: the location of the new bucket if create success
+//     - error: nil if create success otherwise the specific error
+func PutBucket(cli bce.Client, bucket string) (string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return "", err
+	}
+	if resp.IsFail() {
+		return "", resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return resp.Header(http.LOCATION), nil
+}
+
+// DeleteBucket - delete an empty bucket by given name
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name to be deleted
+// RETURNS:
+//     - error: nil if delete success otherwise the specific error
+func DeleteBucket(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketLocation - get the location of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - string: the location of the bucket
+//     - error: nil if delete success otherwise the specific error
+func GetBucketLocation(cli bce.Client, bucket string) (string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("location", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return "", err
+	}
+	if resp.IsFail() {
+		return "", resp.ServiceError()
+	}
+	result := &LocationType{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return "", err
+	}
+	return result.LocationConstraint, nil
+}
+
+// PutBucketAcl - set the acl of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - cannedAcl: support private, public-read, public-read-write
+//     - aclBody: the acl file body
+// RETURNS:
+//     - error: nil if delete success otherwise the specific error
+func PutBucketAcl(cli bce.Client, bucket, cannedAcl string, aclBody *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("acl", "")
+
+	// The acl setting
+	if len(cannedAcl) != 0 && aclBody != nil {
+		return bce.NewBceClientError("BOS does not support cannedAcl and acl file at the same time")
+	}
+	if validCannedAcl(cannedAcl) {
+		req.SetHeader(http.BCE_ACL, cannedAcl)
+	}
+	if aclBody != nil {
+		req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+		req.SetBody(aclBody)
+	}
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketAcl - get the acl of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - *GetBucketAclResult: the result of the bucket acl
+//     - error: nil if success otherwise the specific error
+func GetBucketAcl(cli bce.Client, bucket string) (*GetBucketAclResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("acl", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketAclResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// PutBucketLogging - set the logging prefix of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - logging: the logging prefix json string body
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketLogging(cli bce.Client, bucket string, logging *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("logging", "")
+	req.SetBody(logging)
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketLogging - get the logging config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - *GetBucketLoggingResult: the logging setting of the bucket
+//     - error: nil if success otherwise the specific error
+func GetBucketLogging(cli bce.Client, bucket string) (*GetBucketLoggingResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("logging", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketLoggingResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteBucketLogging - delete the logging setting of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketLogging(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("logging", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// PutBucketLifecycle - set the lifecycle rule of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - lifecycle: the lifecycle rule json string body
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketLifecycle(cli bce.Client, bucket string, lifecycle *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("lifecycle", "")
+	req.SetBody(lifecycle)
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketLifecycle - get the lifecycle rule of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - *GetBucketLifecycleResult: the lifecycle rule of the bucket
+//     - error: nil if success otherwise the specific error
+func GetBucketLifecycle(cli bce.Client, bucket string) (*GetBucketLifecycleResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("lifecycle", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketLifecycleResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteBucketLifecycle - delete the lifecycle rule of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketLifecycle(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("lifecycle", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// PutBucketStorageclass - set the storage class of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - storageClass: the storage class string
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketStorageclass(cli bce.Client, bucket, storageClass string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("storageClass", "")
+
+	obj := &StorageClassType{storageClass}
+	jsonBytes, jsonErr := json.Marshal(obj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	req.SetBody(body)
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketStorageclass - get the storage class of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - string: the storage class of the bucket
+//     - error: nil if success otherwise the specific error
+func GetBucketStorageclass(cli bce.Client, bucket string) (string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("storageClass", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return "", err
+	}
+	if resp.IsFail() {
+		return "", resp.ServiceError()
+	}
+	result := &StorageClassType{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return "", err
+	}
+	return result.StorageClass, nil
+}
+
+// PutBucketReplication - set the bucket replication of different region
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - replicationConf: the replication config body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketReplication(cli bce.Client, bucket string, replicationConf *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("replication", "")
+	if replicationConf != nil {
+		req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+		req.SetBody(replicationConf)
+	}
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketReplication - get the bucket replication config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - *GetBucketReplicationResult: the result of the bucket replication config
+//     - error: nil if success otherwise the specific error
+func GetBucketReplication(cli bce.Client, bucket string) (*GetBucketReplicationResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("replication", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketReplicationResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteBucketReplication - delete the bucket replication config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketReplication(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("replication", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketReplicationProgress - get the bucket replication process of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - *GetBucketReplicationProgressResult: the result of the bucket replication process
+//     - error: nil if success otherwise the specific error
+func GetBucketReplicationProgress(cli bce.Client, bucket string) (
+	*GetBucketReplicationProgressResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("replicationProgress", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketReplicationProgressResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// PutBucketEncryption - set the bucket encrpytion config
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - algorithm: the encryption algorithm
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketEncryption(cli bce.Client, bucket, algorithm string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("encryption", "")
+
+	obj := &BucketEncryptionType{algorithm}
+	jsonBytes, jsonErr := json.Marshal(obj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+	req.SetBody(body)
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketEncryption - get the encryption config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - algorithm: the bucket encryption algorithm
+//     - error: nil if success otherwise the specific error
+func GetBucketEncryption(cli bce.Client, bucket string) (string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("encryption", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return "", err
+	}
+	if resp.IsFail() {
+		return "", resp.ServiceError()
+	}
+	result := &BucketEncryptionType{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return "", err
+	}
+	return result.EncryptionAlgorithm, nil
+}
+
+// DeleteBucketEncryption - delete the encryption config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketEncryption(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("encryption", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// PutBucketStaticWebsite - set the bucket static website config
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - confBody: the static website config body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketStaticWebsite(cli bce.Client, bucket string, confBody *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("website", "")
+	if confBody != nil {
+		req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+		req.SetBody(confBody)
+	}
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketStaticWebsite - get the static website config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - result: the bucket static website config result object
+//     - error: nil if success otherwise the specific error
+func GetBucketStaticWebsite(cli bce.Client, bucket string) (
+	*GetBucketStaticWebsiteResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("website", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketStaticWebsiteResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteBucketStaticWebsite - delete the static website config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketStaticWebsite(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("website", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// PutBucketCors - set the bucket CORS config
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - confBody: the CORS config body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketCors(cli bce.Client, bucket string, confBody *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("cors", "")
+	if confBody != nil {
+		req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+		req.SetBody(confBody)
+	}
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketCors - get the CORS config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - result: the bucket CORS config result object
+//     - error: nil if success otherwise the specific error
+func GetBucketCors(cli bce.Client, bucket string) (
+	*GetBucketCorsResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("cors", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetBucketCorsResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteBucketCors - delete the CORS config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketCors(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("cors", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// PutBucketCopyrightProtection - set the copyright protection config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - resources: the resource items in the bucket to be protected
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutBucketCopyrightProtection(cli bce.Client, bucket string, resources ...string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.PUT)
+	req.SetParam("copyrightProtection", "")
+	if len(resources) == 0 {
+		return bce.NewBceClientError("the resource to set copyright protection is empty")
+	}
+	arg := &CopyrightProtectionType{resources}
+	jsonBytes, jsonErr := json.Marshal(arg)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+	req.SetBody(body)
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetBucketCopyrightProtection - get the copyright protection config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - result: the bucket copyright protection resources array
+//     - error: nil if success otherwise the specific error
+func GetBucketCopyrightProtection(cli bce.Client, bucket string) ([]string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("copyrightProtection", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &CopyrightProtectionType{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result.Resource, nil
+}
+
+// DeleteBucketCopyrightProtection - delete the copyright protection config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteBucketCopyrightProtection(cli bce.Client, bucket string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.DELETE)
+	req.SetParam("copyrightProtection", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}

--- a/github.com/baidubce/bce-sdk-go/services/bos/api/model.go
+++ b/github.com/baidubce/bce-sdk-go/services/bos/api/model.go
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// model.go - definitions of the request arguments and results data structure model
+
+package api
+
+import (
+	"io"
+)
+
+type OwnerType struct {
+	Id          string `json:"id"`
+	DisplayName string `json:"displayName"`
+}
+
+type BucketSummaryType struct {
+	Name         string `json:"name"`
+	Location     string `json:"location"`
+	CreationDate string `json:"creationDate"`
+}
+
+// ListBucketsResult defines the result structure of ListBuckets api.
+type ListBucketsResult struct {
+	Owner   OwnerType           `json:"owner"`
+	Buckets []BucketSummaryType `json:"buckets"`
+}
+
+// ListObjectsArgs defines the optional arguments for ListObjects api.
+type ListObjectsArgs struct {
+	Delimiter string `json:"delimiter"`
+	Marker    string `json:"marker"`
+	MaxKeys   int    `json:"maxKeys"`
+	Prefix    string `json:"prefix"`
+}
+
+type ObjectSummaryType struct {
+	Key          string    `json:"key"`
+	LastModified string    `json:"lastModified"`
+	ETag         string    `json:"eTag"`
+	Size         int       `json:"size"`
+	StorageClass string    `json:"storageClass"`
+	Owner        OwnerType `json:"owner"`
+}
+
+type PrefixType struct {
+	Prefix string `json:"prefix"`
+}
+
+// ListObjectsResult defines the result structure of ListObjects api.
+type ListObjectsResult struct {
+	Name           string              `json:"name"`
+	Prefix         string              `json:"prefix"`
+	Delimiter      string              `json:"delimiter"`
+	Marker         string              `json:"marker"`
+	NextMarker     string              `json:"nextMarker,omitempty"`
+	MaxKeys        int                 `json:"maxKeys"`
+	IsTruncated    bool                `json:"isTruncated"`
+	Contents       []ObjectSummaryType `json:"contents"`
+	CommonPrefixes []PrefixType        `json:"commonPrefixes"`
+}
+
+type LocationType struct {
+	LocationConstraint string `json:"locationConstraint"`
+}
+
+// AclOwnerType defines the owner struct in ACL setting
+type AclOwnerType struct {
+	Id string `json:"id"`
+}
+
+// GranteeType defines the grantee struct in ACL setting
+type GranteeType struct {
+	Id string `json:"id"`
+}
+
+type AclRefererType struct {
+	StringLike   []string `json:"stringLike"`
+	StringEquals []string `json:"stringEquals"`
+}
+
+type AclCondType struct {
+	IpAddress []string       `json:"ipAddress"`
+	Referer   AclRefererType `json:"referer"`
+}
+
+// GrantType defines the grant struct in ACL setting
+type GrantType struct {
+	Grantee     []GranteeType `json:"grantee"`
+	Permission  []string      `json:"permission"`
+	Resource    []string      `json:"resource,omitempty"`
+	NotResource []string      `json:"notResource,omitempty"`
+	Condition   AclCondType   `json:"condition,omitempty"`
+}
+
+// PutBucketAclArgs defines the input args structure for putting bucket acl.
+type PutBucketAclArgs struct {
+	AccessControlList []GrantType `json:"accessControlList"`
+}
+
+// GetBucketAclResult defines the result structure of getting bucket acl.
+type GetBucketAclResult struct {
+	AccessControlList []GrantType  `json:"accessControlList"`
+	Owner             AclOwnerType `json:"owner"`
+}
+
+// PutBucketLoggingArgs defines the input args structure for putting bucket logging.
+type PutBucketLoggingArgs struct {
+	TargetBucket string `json:"targetBucket"`
+	TargetPrefix string `json:"targetPrefix"`
+}
+
+// GetBucketLoggingResult defines the result structure for getting bucket logging.
+type GetBucketLoggingResult struct {
+	Status       string `json:"status"`
+	TargetBucket string `json:"targetBucket,omitempty"`
+	TargetPrefix string `json:"targetPrefix, omitempty"`
+}
+
+// LifecycleConditionTimeType defines the structure of time condition
+type LifecycleConditionTimeType struct {
+	DateGreaterThan string `json:"dateGreaterThan"`
+}
+
+// LifecycleConditionType defines the structure of condition
+type LifecycleConditionType struct {
+	Time LifecycleConditionTimeType `json:"time"`
+}
+
+// LifecycleActionType defines the structure of lifecycle action
+type LifecycleActionType struct {
+	Name         string `json:"name"`
+	StorageClass string `json:"storageClass,omitempty"`
+}
+
+// LifecycleRuleType defines the structure of a single lifecycle rule
+type LifecycleRuleType struct {
+	Id        string                 `json:"id"`
+	Status    string                 `json:"status"`
+	Resource  []string               `json:"resource"`
+	Condition LifecycleConditionType `json:"condition"`
+	Action    LifecycleActionType    `json:"action"`
+}
+
+// GetBucketLifecycleResult defines the lifecycle argument structure for putting
+type PutBucketLifecycleArgs struct {
+	Rule []LifecycleRuleType `json:"rule"`
+}
+
+// GetBucketLifecycleResult defines the lifecycle result structure for getting
+type GetBucketLifecycleResult struct {
+	Rule []LifecycleRuleType `json:"rule"`
+}
+
+type StorageClassType struct {
+	StorageClass string `json:"storageClass"`
+}
+
+// BucketReplicationDescriptor defines the description data structure
+type BucketReplicationDescriptor struct {
+	Bucket       string `json:"bucket,omitempty"`
+	StorageClass string `json:"storageClass,omitempty"`
+}
+
+// BucketReplicationType defines the data structure for Put and Get of bucket replication
+type BucketReplicationType struct {
+	Id               string                       `json:"id"`
+	Status           string                       `json:"status"`
+	Resource         []string                     `json:"resource"`
+	ReplicateDeletes string                       `json:"replicateDeletes"`
+	Destination      *BucketReplicationDescriptor `json:"destination,omitempty"`
+	ReplicateHistory *BucketReplicationDescriptor `json:"replicateHistory,omitempty"`
+}
+
+type PutBucketReplicationArgs BucketReplicationType
+type GetBucketReplicationResult BucketReplicationType
+
+// GetBucketReplicationProgressResult defines output result for replication process
+type GetBucketReplicationProgressResult struct {
+	Status                    string  `json:"status"`
+	HistoryReplicationPercent float64 `json:"historyReplicationPercent"`
+	LatestReplicationTime     string  `json:"latestReplicationTime"`
+}
+
+// BucketEncryptionType defines the data structure for Put and Get of bucket encryption
+type BucketEncryptionType struct {
+	EncryptionAlgorithm string `json:"encryptionAlgorithm"`
+}
+
+// BucketStaticWebsiteType defines the data structure for Put and Get of bucket static website
+type BucketStaticWebsiteType struct {
+	Index    string `json:"index"`
+	NotFound string `json:"notFound"`
+}
+
+type PutBucketStaticWebsiteArgs BucketStaticWebsiteType
+type GetBucketStaticWebsiteResult BucketStaticWebsiteType
+
+type BucketCORSType struct {
+	AllowedOrigins       []string `json:"allowedOrigins"`
+	AllowedMethods       []string `json:"allowedMethods"`
+	AllowedHeaders       []string `json:"allowedHeaders,omitempty"`
+	AllowedExposeHeaders []string `json:"allowedExposeHeaders,omitempty"`
+	MaxAgeSeconds        int64    `json:"maxAgeSeconds,omitempty"`
+}
+
+// PutBucketCorsArgs defines the request argument for bucket CORS setting
+type PutBucketCorsArgs struct {
+	CorsConfiguration []BucketCORSType `json:"corsConfiguration"`
+}
+
+// GetBucketCorsResult defines the data structure of getting bucket CORS result
+type GetBucketCorsResult struct {
+	CorsConfiguration []BucketCORSType `json:"corsConfiguration"`
+}
+
+// CopyrightProtectionType defines the data structure for Put and Get copyright protection API
+type CopyrightProtectionType struct {
+	Resource []string `json:"resource"`
+}
+
+// ObjectAclType defines the data structure for Put and Get object acl API
+type ObjectAclType struct {
+	AccessControlList []GrantType `json:"accessControlList"`
+}
+
+type PutObjectAclArgs ObjectAclType
+type GetObjectAclResult ObjectAclType
+
+// PutObjectArgs defines the optional args structure for the put object api.
+type PutObjectArgs struct {
+	CacheControl       string
+	ContentDisposition string
+	ContentMD5         string
+	ContentType        string
+	ContentLength      int64
+	Expires            string
+	UserMeta           map[string]string
+	ContentSha256      string
+	StorageClass       string
+}
+
+// CopyObjectArgs defines the optional args structure for the copy object api.
+type CopyObjectArgs struct {
+	ObjectMeta
+	MetadataDirective string
+	IfMatch           string
+	IfNoneMatch       string
+	IfModifiedSince   string
+	IfUnmodifiedSince string
+}
+
+// CopyObjectResult defines the result json structure for the copy object api.
+type CopyObjectResult struct {
+	LastModified string `json:"lastModified"`
+	ETag         string `json:"eTag"`
+}
+
+type ObjectMeta struct {
+	CacheControl       string
+	ContentDisposition string
+	ContentEncoding    string
+	ContentLength      int64
+	ContentRange       string
+	ContentType        string
+	ContentMD5         string
+	ContentSha256      string
+	Expires            string
+	LastModified       string
+	ETag               string
+	UserMeta           map[string]string
+	StorageClass       string
+	NextAppendOffset   string
+	ObjectType         string
+}
+
+// GetObjectResult defines the result data of the get object api.
+type GetObjectResult struct {
+	ObjectMeta
+	ContentLanguage string
+	Body            io.ReadCloser
+}
+
+// GetObjectMetaResult defines the result data of the get object meta api.
+type GetObjectMetaResult struct {
+	ObjectMeta
+}
+
+// FetchObjectArgs defines the optional arguments structure for the fetch object api.
+type FetchObjectArgs struct {
+	FetchMode    string
+	StorageClass string
+}
+
+// FetchObjectResult defines the result json structure for the fetch object api.
+type FetchObjectResult struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	RequestId string `json:"requestId"`
+	JobId     string `json:"jobId"`
+}
+
+// AppendObjectArgs defines the optional arguments structure for appending object.
+type AppendObjectArgs struct {
+	Offset             int64
+	CacheControl       string
+	ContentDisposition string
+	ContentMD5         string
+	ContentType        string
+	Expires            string
+	UserMeta           map[string]string
+	ContentSha256      string
+	StorageClass       string
+}
+
+// AppendObjectResult defines the result data structure for appending object.
+type AppendObjectResult struct {
+	ContentMD5       string
+	NextAppendOffset int64
+	ETag             string
+}
+
+// DeleteObjectArgs defines the input args structure for a single object.
+type DeleteObjectArgs struct {
+	Key string `json:"key"`
+}
+
+// DeleteMultipleObjectsResult defines the input args structure for deleting multiple objects.
+type DeleteMultipleObjectsArgs struct {
+	Objects []DeleteObjectArgs `json:"objects"`
+}
+
+// DeleteObjectResult defines the result structure for deleting a single object.
+type DeleteObjectResult struct {
+	Key     string `json:"key"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// DeleteMultipleObjectsResult defines the result structure for deleting multiple objects.
+type DeleteMultipleObjectsResult struct {
+	Errors []DeleteObjectResult `json:"errors"`
+}
+
+// InitiateMultipartUploadArgs defines the input arguments to initiate a multipart upload.
+type InitiateMultipartUploadArgs struct {
+	CacheControl       string
+	ContentDisposition string
+	Expires            string
+	StorageClass       string
+}
+
+// InitiateMultipartUploadResult defines the result structure to initiate a multipart upload.
+type InitiateMultipartUploadResult struct {
+	Bucket   string `json:"bucket"`
+	Key      string `json:"key"`
+	UploadId string `json:"uploadId"`
+}
+
+// UploadPartArgs defines the optinoal argumets for uploading part.
+type UploadPartArgs struct {
+	ContentMD5    string
+	ContentSha256 string
+}
+
+// UploadPartCopyArgs defines the optional arguments of UploadPartCopy.
+type UploadPartCopyArgs struct {
+	SourceRange       string
+	IfMatch           string
+	IfNoneMatch       string
+	IfModifiedSince   string
+	IfUnmodifiedSince string
+}
+
+// UploadInfoType defines an uploaded part info structure.
+type UploadInfoType struct {
+	PartNumber int    `json:"partNumber"`
+	ETag       string `json:"eTag"`
+}
+
+// CompleteMultipartUploadArgs defines the input arguments structure of CompleteMultipartUpload.
+type CompleteMultipartUploadArgs struct {
+	Parts []UploadInfoType `json:"parts"`
+}
+
+// CompleteMultipartUploadResult defines the result structure of CompleteMultipartUpload.
+type CompleteMultipartUploadResult struct {
+	Location string `json:"location"`
+	Bucket   string `json:"bucket"`
+	Key      string `json:"key"`
+	ETag     string `json:"eTag"`
+}
+
+// ListPartsArgs defines the input optional arguments of listing parts information.
+type ListPartsArgs struct {
+	MaxParts         int
+	PartNumberMarker string
+}
+
+type ListPartType struct {
+	PartNumber   int    `json:"partNumber"`
+	LastModified string `json:"lastModified"`
+	ETag         string `json:"eTag"`
+	Size         int    `json:"size"`
+}
+
+// ListPartsResult defines the parts info result from ListParts.
+type ListPartsResult struct {
+	Bucket               string         `json:"bucket"`
+	Key                  string         `json:"key"`
+	UploadId             string         `json:"uploadId"`
+	Initiated            string         `json:"initiated"`
+	Owner                OwnerType      `json:"owner"`
+	StorageClass         string         `json:"storageClass"`
+	PartNumberMarker     int            `json:"partNumberMarker"`
+	NextPartNumberMarker int            `json:"nextPartNumberMarker"`
+	MaxParts             int            `json:"maxParts"`
+	IsTruncated          bool           `json:"isTruncated"`
+	Parts                []ListPartType `json:"parts"`
+}
+
+// ListMultipartUploadsArgs defines the optional arguments for ListMultipartUploads.
+type ListMultipartUploadsArgs struct {
+	Delimiter  string
+	KeyMarker  string
+	MaxUploads int
+	Prefix     string
+}
+
+type ListMultipartUploadsType struct {
+	Key          string    `json:"key"`
+	UploadId     string    `json:"uploadId"`
+	Owner        OwnerType `json:"owner"`
+	Initiated    string    `json:"initiated"`
+	StorageClass string    `json:"storageClass,omitempty"`
+}
+
+// ListMultipartUploadsResult defines the multipart uploads result structure.
+type ListMultipartUploadsResult struct {
+	Bucket         string                     `json:"bucket"`
+	CommonPrefixes []PrefixType               `json:"commonPrefixes"`
+	Delimiter      string                     `json:"delimiter"`
+	Prefix         string                     `json:"prefix"`
+	IsTruncated    bool                       `json:"isTruncated"`
+	KeyMarker      string                     `json:"keyMarker"`
+	MaxUploads     int                        `json:"maxUploads"`
+	NextKeyMarker  string                     `json:"nextKeyMarker"`
+	Uploads        []ListMultipartUploadsType `json:"uploads"`
+}

--- a/github.com/baidubce/bce-sdk-go/services/bos/api/multipart.go
+++ b/github.com/baidubce/bce-sdk-go/services/bos/api/multipart.go
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// multipart.go - the multipart-related APIs definition supported by the BOS service
+
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/http"
+	"github.com/baidubce/bce-sdk-go/util"
+)
+
+// InitiateMultipartUpload - initiate a multipart upload to get a upload ID
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - object: the object name
+//     - contentType: the content type of the object to be uploaded which should be specified,
+//       otherwise use the default(application/octet-stream)
+//     - args: the optional arguments
+// RETURNS:
+//     - *InitiateMultipartUploadResult: the result data structure
+//     - error: nil if ok otherwise the specific error
+func InitiateMultipartUpload(cli bce.Client, bucket, object, contentType string,
+	args *InitiateMultipartUploadArgs) (*InitiateMultipartUploadResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.POST)
+	req.SetParam("uploads", "")
+	if len(contentType) == 0 {
+		contentType = RAW_CONTENT_TYPE
+	}
+	req.SetHeader(http.CONTENT_TYPE, contentType)
+
+	// Optional arguments settings
+	if args != nil {
+		setOptionalNullHeaders(req, map[string]string{
+			http.CACHE_CONTROL:       args.CacheControl,
+			http.CONTENT_DISPOSITION: args.ContentDisposition,
+			http.EXPIRES:             args.Expires,
+		})
+
+		if validStorageClass(args.StorageClass) {
+			req.SetHeader(http.BCE_STORAGE_CLASS, args.StorageClass)
+		} else {
+			if len(args.StorageClass) != 0 {
+				return nil, bce.NewBceClientError("invalid storage class value: " +
+					args.StorageClass)
+			}
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &InitiateMultipartUploadResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// UploadPart - upload the single part in the multipart upload process
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - object: the object name
+//     - uploadId: the multipart upload id
+//     - partNumber: the current part number
+//     - content: the uploaded part content
+//     - args: the optional arguments
+// RETURNS:
+//     - string: the etag of the uploaded part
+//     - error: nil if ok otherwise the specific error
+func UploadPart(cli bce.Client, bucket, object, uploadId string, partNumber int,
+	content *bce.Body, args *UploadPartArgs) (string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.PUT)
+	req.SetParam("uploadId", uploadId)
+	req.SetParam("partNumber", fmt.Sprintf("%d", partNumber))
+	if content == nil {
+		return "", bce.NewBceClientError("upload part content should not be empty")
+	}
+	if content.Size() >= THRESHOLD_100_CONTINUE {
+		req.SetHeader("Expect", "100-continue")
+	}
+	req.SetBody(content)
+
+	// Optional arguments settings
+	if args != nil {
+		setOptionalNullHeaders(req, map[string]string{
+			http.CONTENT_MD5:        args.ContentMD5,
+			http.BCE_CONTENT_SHA256: args.ContentSha256,
+		})
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return "", err
+	}
+	if resp.IsFail() {
+		return "", resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return strings.Trim(resp.Header(http.ETAG), "\""), nil
+}
+
+// UploadPartCopy - copy the multipart data
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - source: the copy source uri
+//     - uploadId: the multipart upload id
+//     - partNumber: the current part number
+//     - args: the optional arguments
+// RETURNS:
+//     - *CopyObjectResult: the lastModified and eTag of the part
+//     - error: nil if ok otherwise the specific error
+func UploadPartCopy(cli bce.Client, bucket, object, source, uploadId string, partNumber int,
+	args *UploadPartCopyArgs) (*CopyObjectResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.PUT)
+	req.SetParam("uploadId", uploadId)
+	req.SetParam("partNumber", fmt.Sprintf("%d", partNumber))
+	if len(source) == 0 {
+		return nil, bce.NewBceClientError("upload part copy source should not be empty")
+	}
+	req.SetHeader(http.BCE_COPY_SOURCE, util.UriEncode(source, false))
+
+	// Optional arguments settings
+	if args != nil {
+		setOptionalNullHeaders(req, map[string]string{
+			http.BCE_COPY_SOURCE_RANGE:               args.SourceRange,
+			http.BCE_COPY_SOURCE_IF_MATCH:            args.IfMatch,
+			http.BCE_COPY_SOURCE_IF_NONE_MATCH:       args.IfNoneMatch,
+			http.BCE_COPY_SOURCE_IF_MODIFIED_SINCE:   args.IfModifiedSince,
+			http.BCE_COPY_SOURCE_IF_UNMODIFIED_SINCE: args.IfUnmodifiedSince,
+		})
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &CopyObjectResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CompleteMultipartUpload - finish a multipart upload operation
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+//     - parts: all parts info stream
+//     - meta: user defined meta data
+// RETURNS:
+//     - *CompleteMultipartUploadResult: the result data
+//     - error: nil if ok otherwise the specific error
+func CompleteMultipartUpload(cli bce.Client, bucket, object, uploadId string,
+	parts *bce.Body, meta map[string]string) (*CompleteMultipartUploadResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.POST)
+	req.SetParam("uploadId", uploadId)
+	if parts == nil {
+		return nil, bce.NewBceClientError("upload parts info should not be emtpy")
+	}
+	if parts.Size() >= THRESHOLD_100_CONTINUE {
+		req.SetHeader("Expect", "100-continue")
+	}
+	req.SetBody(parts)
+
+	// Optional arguments settings
+	if meta != nil {
+		if err := setUserMetadata(req, meta); err != nil {
+			return nil, err
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &CompleteMultipartUploadResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// AbortMultipartUpload - abort a multipart upload operation
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+// RETURNS:
+//     - error: nil if ok otherwise the specific error
+func AbortMultipartUpload(cli bce.Client, bucket, object, uploadId string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.DELETE)
+	req.SetParam("uploadId", uploadId)
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// ListParts - list the successfully uploaded parts info by upload id
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+//     - args: the optional arguments
+//             partNumberMarker: return parts after this marker
+//             maxParts: the max number of return parts, default and maximum is 1000
+// RETURNS:
+//     - *ListPartsResult: the uploaded parts info result
+//     - error: nil if ok otherwise the specific error
+func ListParts(cli bce.Client, bucket, object, uploadId string,
+	args *ListPartsArgs) (*ListPartsResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.GET)
+	req.SetParam("uploadId", uploadId)
+
+	// Optional arguments settings
+	if args != nil {
+		if len(args.PartNumberMarker) > 0 {
+			req.SetParam("partNumberMarker", args.PartNumberMarker)
+		}
+		if args.MaxParts > 0 {
+			req.SetParam("maxParts", fmt.Sprintf("%d", args.MaxParts))
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &ListPartsResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListMultipartUploads - list the unfinished uploaded parts of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the destination bucket name
+//     - args: the optional arguments
+// RETURNS:
+//     - *ListMultipartUploadsResult: the unfinished uploaded parts info result
+//     - error: nil if ok otherwise the specific error
+func ListMultipartUploads(cli bce.Client, bucket string,
+	args *ListMultipartUploadsArgs) (*ListMultipartUploadsResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.GET)
+	req.SetParam("uploads", "")
+
+	// Optional arguments settings
+	if args != nil {
+		if len(args.Delimiter) > 0 {
+			req.SetParam("delimiter", args.Delimiter)
+		}
+		if len(args.KeyMarker) > 0 {
+			req.SetParam("keyMarker", args.KeyMarker)
+		}
+		if args.MaxUploads > 0 {
+			req.SetParam("maxUploads", fmt.Sprintf("%d", args.MaxUploads))
+		}
+		if len(args.Prefix) > 0 {
+			req.SetParam("prefix", args.Prefix)
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &ListMultipartUploadsResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/github.com/baidubce/bce-sdk-go/services/bos/api/object.go
+++ b/github.com/baidubce/bce-sdk-go/services/bos/api/object.go
@@ -1,0 +1,751 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// object.go - the object APIs definition supported by the BOS service
+
+package api
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/baidubce/bce-sdk-go/auth"
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/http"
+	"github.com/baidubce/bce-sdk-go/util"
+)
+
+// PutObject - put the object from the string or the stream
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name of the object
+//     - object: the name of the object
+//     - body: the input content of the object
+//     - args: the optional arguments of this api
+// RETURNS:
+//     - string: the etag of the object
+//     - error: nil if ok otherwise the specific error
+func PutObject(cli bce.Client, bucket, object string, body *bce.Body,
+	args *PutObjectArgs) (string, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.PUT)
+	if body == nil {
+		return "", bce.NewBceClientError("PutObject body should not be emtpy")
+	}
+	if body.Size() >= THRESHOLD_100_CONTINUE {
+		req.SetHeader("Expect", "100-continue")
+	}
+	req.SetBody(body)
+
+	// Optional arguments settings
+	if args != nil {
+		setOptionalNullHeaders(req, map[string]string{
+			http.CACHE_CONTROL:       args.CacheControl,
+			http.CONTENT_DISPOSITION: args.ContentDisposition,
+			http.CONTENT_TYPE:        args.ContentType,
+			http.EXPIRES:             args.Expires,
+			http.BCE_CONTENT_SHA256:  args.ContentSha256,
+		})
+		if args.ContentLength != 0 {
+			// User specified Content-Length can be smaller than the body size, so the body should
+			// be reset. The `net/http.Client' does not support the Content-Length bigger than the
+			// body size.
+			if args.ContentLength > body.Size() {
+				return "", bce.NewBceClientError("content-length can't be bigger than body size")
+			}
+			if args.ContentLength < 0 {
+				return "", bce.NewBceClientError("content-length can't be a negative number")
+			}
+			body, err := bce.NewBodyFromSizedReader(body.Stream(), args.ContentLength)
+			if err != nil {
+				return "", bce.NewBceClientError(err.Error())
+			}
+			req.SetBody(body)
+			req.SetHeader(http.CONTENT_LENGTH, fmt.Sprintf("%d", args.ContentLength))
+		}
+
+		// Reset the contentMD5 if set by user
+		if len(args.ContentMD5) != 0 {
+			req.SetHeader(http.CONTENT_MD5, args.ContentMD5)
+		}
+
+		if validStorageClass(args.StorageClass) {
+			req.SetHeader(http.BCE_STORAGE_CLASS, args.StorageClass)
+		} else {
+			if len(args.StorageClass) != 0 {
+				return "", bce.NewBceClientError("invalid storage class value: " +
+					args.StorageClass)
+			}
+		}
+		if err := setUserMetadata(req, args.UserMeta); err != nil {
+			return "", err
+		}
+	}
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return "", err
+	}
+	if resp.IsFail() {
+		return "", resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return strings.Trim(resp.Header(http.ETAG), "\""), nil
+}
+
+// CopyObject - copy one object to a new object with new bucket and/or name. It can alse set the
+// metadata of the object with the same source and target.
+//
+// PARAMS:
+//     - cli: the client object which can perform sending request
+//     - bucket: the bucket name of the target object
+//     - object: the name of the target object
+//     - source: the source object uri
+//     - *CopyObjectArgs: the optional input args for copying object
+// RETURNS:
+//     - *CopyObjectResult: the result object which contains etag and lastmodified
+//     - error: nil if ok otherwise the specific error
+func CopyObject(cli bce.Client, bucket, object, source string,
+	args *CopyObjectArgs) (*CopyObjectResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.PUT)
+	if len(source) == 0 {
+		return nil, bce.NewBceClientError("copy source should not be null")
+	}
+	req.SetHeader(http.BCE_COPY_SOURCE, util.UriEncode(source, false))
+
+	// Optional arguments settings
+	if args != nil {
+		setOptionalNullHeaders(req, map[string]string{
+			http.CACHE_CONTROL:                       args.CacheControl,
+			http.CONTENT_DISPOSITION:                 args.ContentDisposition,
+			http.CONTENT_ENCODING:                    args.ContentEncoding,
+			http.CONTENT_RANGE:                       args.ContentRange,
+			http.CONTENT_TYPE:                        args.ContentType,
+			http.EXPIRES:                             args.Expires,
+			http.LAST_MODIFIED:                       args.LastModified,
+			http.ETAG:                                args.ETag,
+			http.CONTENT_MD5:                         args.ContentMD5,
+			http.BCE_CONTENT_SHA256:                  args.ContentSha256,
+			http.BCE_OBJECT_TYPE:                     args.ObjectType,
+			http.BCE_NEXT_APPEND_OFFSET:              args.NextAppendOffset,
+			http.BCE_COPY_SOURCE_IF_MATCH:            args.IfMatch,
+			http.BCE_COPY_SOURCE_IF_NONE_MATCH:       args.IfNoneMatch,
+			http.BCE_COPY_SOURCE_IF_MODIFIED_SINCE:   args.IfModifiedSince,
+			http.BCE_COPY_SOURCE_IF_UNMODIFIED_SINCE: args.IfUnmodifiedSince,
+		})
+		if args.ContentLength != 0 {
+			req.SetHeader(http.CONTENT_LENGTH, fmt.Sprintf("%d", args.ContentLength))
+		}
+		if validMetadataDirective(args.MetadataDirective) {
+			req.SetHeader(http.BCE_COPY_METADATA_DIRECTIVE, args.MetadataDirective)
+		} else {
+			if len(args.MetadataDirective) != 0 {
+				return nil, bce.NewBceClientError(
+					"invalid metadata directive value: " + args.MetadataDirective)
+			}
+		}
+		if validStorageClass(args.StorageClass) {
+			req.SetHeader(http.BCE_STORAGE_CLASS, args.StorageClass)
+		} else {
+			if len(args.StorageClass) != 0 {
+				return nil, bce.NewBceClientError("invalid storage class value: " +
+					args.StorageClass)
+			}
+		}
+		if err := setUserMetadata(req, args.UserMeta); err != nil {
+			return nil, err
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	jsonBody := &CopyObjectResult{}
+	if err := resp.ParseJsonBody(jsonBody); err != nil {
+		return nil, err
+	}
+	return jsonBody, nil
+}
+
+// GetObject - get the object content with range and response-headers-specified support
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name of the object
+//     - object: the name of the object
+//     - responseHeaders: the optional response headers to get the given object
+//     - ranges: the optional range start and end to get the given object
+// RETURNS:
+//     - *GetObjectResult: the output content result of the object
+//     - error: nil if ok otherwise the specific error
+func GetObject(cli bce.Client, bucket, object string, responseHeaders map[string]string,
+	ranges ...int64) (*GetObjectResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.GET)
+
+	// Optional arguments settings
+	if responseHeaders != nil {
+		for k, v := range responseHeaders {
+			if _, ok := GET_OBJECT_ALLOWED_RESPONSE_HEADERS[k]; ok {
+				req.SetParam("response"+k, v)
+			}
+		}
+	}
+	if len(ranges) != 0 {
+		rangeStr := "bytes="
+		if len(ranges) == 1 {
+			rangeStr += fmt.Sprintf("%d", ranges[0]) + "-"
+		} else {
+			rangeStr += fmt.Sprintf("%d", ranges[0]) + "-" + fmt.Sprintf("%d", ranges[1])
+		}
+		req.SetHeader("Range", rangeStr)
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	headers := resp.Headers()
+	result := &GetObjectResult{}
+	if val, ok := headers[http.CACHE_CONTROL]; ok {
+		result.CacheControl = val
+	}
+	if val, ok := headers[http.CONTENT_DISPOSITION]; ok {
+		result.ContentDisposition = val
+	}
+	if val, ok := headers[http.CONTENT_LENGTH]; ok {
+		if length, err := strconv.ParseInt(val, 10, 64); err == nil {
+			result.ContentLength = length
+		}
+	}
+	if val, ok := headers[http.CONTENT_RANGE]; ok {
+		result.ContentRange = val
+	}
+	if val, ok := headers[http.CONTENT_TYPE]; ok {
+		result.ContentType = val
+	}
+	if val, ok := headers[http.CONTENT_MD5]; ok {
+		result.ContentMD5 = val
+	}
+	if val, ok := headers[http.EXPIRES]; ok {
+		result.Expires = val
+	}
+	if val, ok := headers[http.LAST_MODIFIED]; ok {
+		result.LastModified = val
+	}
+	if val, ok := headers[http.ETAG]; ok {
+		result.ETag = strings.Trim(val, "\"")
+	}
+	if val, ok := headers[http.CONTENT_LANGUAGE]; ok {
+		result.ContentLanguage = val
+	}
+	if val, ok := headers[http.CONTENT_ENCODING]; ok {
+		result.ContentEncoding = val
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_CONTENT_SHA256)]; ok {
+		result.ContentSha256 = val
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_STORAGE_CLASS)]; ok {
+		result.StorageClass = val
+	}
+	bcePrefix := toHttpHeaderKey(http.BCE_USER_METADATA_PREFIX)
+	for k, v := range headers {
+		if strings.Index(k, bcePrefix) == 0 {
+			if result.UserMeta == nil {
+				result.UserMeta = make(map[string]string)
+			}
+			result.UserMeta[k[len(bcePrefix):]] = v
+		}
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_OBJECT_TYPE)]; ok {
+		result.ObjectType = val
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_NEXT_APPEND_OFFSET)]; ok {
+		result.NextAppendOffset = val
+	}
+	result.Body = resp.Body()
+	return result, nil
+}
+
+// GetObjectMeta - get the meta data of the given object
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name of the object
+//     - object: the name of the object
+// RETURNS:
+//     - *GetObjectMetaResult: the result of this api
+//     - error: nil if ok otherwise the specific error
+func GetObjectMeta(cli bce.Client, bucket, object string) (*GetObjectMetaResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.HEAD)
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	headers := resp.Headers()
+	result := &GetObjectMetaResult{}
+	if val, ok := headers[http.CACHE_CONTROL]; ok {
+		result.CacheControl = val
+	}
+	if val, ok := headers[http.CONTENT_DISPOSITION]; ok {
+		result.ContentDisposition = val
+	}
+	if val, ok := headers[http.CONTENT_LENGTH]; ok {
+		if length, err := strconv.ParseInt(val, 10, 64); err == nil {
+			result.ContentLength = length
+		}
+	}
+	if val, ok := headers[http.CONTENT_RANGE]; ok {
+		result.ContentRange = val
+	}
+	if val, ok := headers[http.CONTENT_TYPE]; ok {
+		result.ContentType = val
+	}
+	if val, ok := headers[http.CONTENT_MD5]; ok {
+		result.ContentMD5 = val
+	}
+	if val, ok := headers[http.EXPIRES]; ok {
+		result.Expires = val
+	}
+	if val, ok := headers[http.LAST_MODIFIED]; ok {
+		result.LastModified = val
+	}
+	if val, ok := headers[http.ETAG]; ok {
+		result.ETag = strings.Trim(val, "\"")
+	}
+	if val, ok := headers[http.CONTENT_ENCODING]; ok {
+		result.ContentEncoding = val
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_CONTENT_SHA256)]; ok {
+		result.ContentSha256 = val
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_STORAGE_CLASS)]; ok {
+		result.StorageClass = val
+	}
+	bcePrefix := toHttpHeaderKey(http.BCE_USER_METADATA_PREFIX)
+	for k, v := range headers {
+		if strings.Index(k, bcePrefix) == 0 {
+			if result.UserMeta == nil {
+				result.UserMeta = make(map[string]string)
+			}
+			result.UserMeta[k[len(bcePrefix):]] = v
+		}
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_OBJECT_TYPE)]; ok {
+		result.ObjectType = val
+	}
+	if val, ok := headers[toHttpHeaderKey(http.BCE_NEXT_APPEND_OFFSET)]; ok {
+		result.NextAppendOffset = val
+	}
+	defer func() { resp.Body().Close() }()
+	return result, nil
+}
+
+// FetchObject - fetch the object by the given url and store it to a bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name to store the object
+//     - object: the name of the object to be stored
+//     - source: the source url to fetch
+//     - args: the optional arguments to perform the fetch operation
+// RETURNS:
+//     - *FetchObjectArgs: the result of this api
+//     - error: nil if ok otherwise the specific error
+func FetchObject(cli bce.Client, bucket, object, source string,
+	args *FetchObjectArgs) (*FetchObjectResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.POST)
+	req.SetParam("fetch", "")
+	if len(source) == 0 {
+		return nil, bce.NewBceClientError("invalid fetch source value: " + source)
+	}
+	req.SetHeader(http.BCE_PREFIX+"fetch-source", source)
+
+	// Optional arguments settings
+	if args != nil {
+		if validFetchMode(args.FetchMode) {
+			req.SetHeader(http.BCE_PREFIX+"fetch-mode", args.FetchMode)
+		} else {
+			if len(args.FetchMode) != 0 {
+				return nil, bce.NewBceClientError("invalid fetch mode value: " + args.FetchMode)
+			}
+		}
+		if validStorageClass(args.StorageClass) {
+			req.SetHeader(http.BCE_STORAGE_CLASS, args.StorageClass)
+		} else {
+			if len(args.StorageClass) != 0 {
+				return nil, bce.NewBceClientError("invalid storage class value: " +
+					args.StorageClass)
+			}
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	jsonBody := &FetchObjectResult{}
+	if err := resp.ParseJsonBody(jsonBody); err != nil {
+		return nil, err
+	}
+	return jsonBody, nil
+}
+
+// AppendObject - append the given content to a new or existed object which is appendable
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name of the object
+//     - object: the name of the object
+//     - content: the content to be appended
+//     - args: the optional arguments to perform the append operation
+// RETURNS:
+//     - *AppendObjectResult: the result status for this api
+//     - error: nil if ok otherwise the specific error
+func AppendObject(cli bce.Client, bucket, object string, content *bce.Body,
+	args *AppendObjectArgs) (*AppendObjectResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.POST)
+	req.SetParam("append", "")
+	if content == nil {
+		return nil, bce.NewBceClientError("AppendObject body should not be emtpy")
+	}
+	if content.Size() >= THRESHOLD_100_CONTINUE {
+		req.SetHeader("Expect", "100-continue")
+	}
+	req.SetBody(content)
+
+	// Optional arguments settings
+	if args != nil {
+		if args.Offset < 0 {
+			return nil, bce.NewBceClientError(
+				fmt.Sprintf("invalid append offset value: %d", args.Offset))
+		}
+		if args.Offset > 0 {
+			req.SetParam("offset", fmt.Sprintf("%d", args.Offset))
+		}
+		setOptionalNullHeaders(req, map[string]string{
+			http.CACHE_CONTROL:       args.CacheControl,
+			http.CONTENT_DISPOSITION: args.ContentDisposition,
+			http.CONTENT_MD5:         args.ContentMD5,
+			http.CONTENT_TYPE:        args.ContentType,
+			http.EXPIRES:             args.Expires,
+			http.BCE_CONTENT_SHA256:  args.ContentSha256,
+		})
+
+		if validStorageClass(args.StorageClass) {
+			req.SetHeader(http.BCE_STORAGE_CLASS, args.StorageClass)
+		} else {
+			if len(args.StorageClass) != 0 {
+				return nil, bce.NewBceClientError("invalid storage class value: " +
+					args.StorageClass)
+			}
+		}
+		if err := setUserMetadata(req, args.UserMeta); err != nil {
+			return nil, err
+		}
+	}
+
+	// Send request and get the result
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	nextOffset, offsetErr := strconv.ParseInt(
+		resp.Header(http.BCE_PREFIX+"next-append-offset"), 10, 64)
+	if offsetErr != nil {
+		nextOffset = content.Size()
+	}
+	result := &AppendObjectResult{
+		resp.Header(http.CONTENT_MD5),
+		nextOffset,
+		strings.Trim(resp.Header(http.ETAG), "\"")}
+	defer func() { resp.Body().Close() }()
+	return result, nil
+}
+
+// DeleteObject - delete the given object
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name of the object to be deleted
+//     - object: the name of the object
+// RETURNS:
+//     - error: nil if ok otherwise the specific error
+func DeleteObject(cli bce.Client, bucket, object string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.DELETE)
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// DeleteMultipleObjects - delete the given objects within a single http request
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name of the objects to be deleted
+//     - objectListStream: the objects list to be delete with json format
+// RETURNS:
+//     - *DeleteMultipleObjectsResult: the objects failed to delete
+//     - error: nil if ok otherwise the specific error
+func DeleteMultipleObjects(cli bce.Client, bucket string,
+	objectListStream *bce.Body) (*DeleteMultipleObjectsResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getBucketUri(bucket))
+	req.SetMethod(http.POST)
+	req.SetParam("delete", "")
+	req.SetHeader(http.CONTENT_TYPE, "application/json; charset=utf-8")
+	if objectListStream == nil {
+		return nil, bce.NewBceClientError("DeleteMultipleObjects body should not be emtpy")
+	}
+	if objectListStream.Size() >= THRESHOLD_100_CONTINUE {
+		req.SetHeader("Expect", "100-continue")
+	}
+	req.SetBody(objectListStream)
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	jsonBody := &DeleteMultipleObjectsResult{}
+	if err := resp.ParseJsonBody(jsonBody); err != nil {
+		return nil, err
+	}
+	return jsonBody, nil
+}
+
+// GeneratePresignedUrl - generate an authorization url with expire time and optional arguments
+//
+// PARAMS:
+//     - conf: the client configuration
+//     - signer: the client signer object to generate the authorization string
+//     - bucket: the target bucket name
+//     - object: the target object name
+//     - expire: expire time in seconds
+//     - method: optional sign method, default is GET
+//     - headers: optional sign headers, default just set the Host
+//     - params: optional sign params, default is empty
+// RETURNS:
+//     - string: the presigned url with authorization string
+func GeneratePresignedUrl(conf *bce.BceClientConfiguration, signer auth.Signer, bucket,
+	object string, expire int, method string, headers, params map[string]string) string {
+	req := &bce.BceRequest{}
+
+	// Set basic arguments
+	if len(method) == 0 {
+		method = http.GET
+	}
+	req.SetMethod(method)
+	req.SetEndpoint(conf.Endpoint)
+	if req.Protocol() == "" {
+		req.SetProtocol(bce.DEFAULT_PROTOCOL)
+	}
+	domain := req.Host()
+	if pos := strings.Index(domain, ":"); pos != -1 {
+		domain = domain[:pos]
+	}
+	if len(bucket) != 0 && net.ParseIP(domain) == nil { // not use an IP as the endpoint by client
+		req.SetUri(bce.URI_PREFIX + object)
+		req.SetHost(bucket + "." + req.Host())
+	} else {
+		req.SetUri(getObjectUri(bucket, object))
+	}
+
+	// Set headers and params if given.
+	req.SetHeader(http.HOST, req.Host())
+	if headers != nil {
+		for k, v := range headers {
+			req.SetHeader(k, v)
+		}
+	}
+	if params != nil {
+		for k, v := range params {
+			req.SetParam(k, v)
+		}
+	}
+
+	// Copy one SignOptions object to rewrite it.
+	option := *conf.SignOption
+	if expire != 0 {
+		option.ExpireSeconds = expire
+	}
+
+	// Generate the authorization string and return the signed url.
+	signer.Sign(&req.Request, conf.Credentials, &option)
+	req.SetParam("authorization", req.Header(http.AUTHORIZATION))
+	return fmt.Sprintf("%s://%s%s?%s", req.Protocol(), req.Host(),
+		util.UriEncode(req.Uri(), false), req.QueryString())
+}
+
+// PutObjectAcl - set the ACL of the given object
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - object: the object name
+//     - cannedAcl: support private and public-read
+//     - grantRead: user id list
+//     - grantFullControl: user id list
+//     - aclBody: the acl file body
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func PutObjectAcl(cli bce.Client, bucket, object, cannedAcl string,
+	grantRead, grantFullControl []string, aclBody *bce.Body) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.PUT)
+	req.SetParam("acl", "")
+
+	// Joiner for generate the user id list string for grant acl header
+	joiner := func(ids []string) string {
+		for i := range ids {
+			ids[i] = "id=\"" + ids[i] + "\""
+		}
+		return strings.Join(ids, ",")
+	}
+
+	// Choose a acl setting method
+	methods := 0
+	if len(cannedAcl) != 0 {
+		methods += 1
+		if validCannedAcl(cannedAcl) {
+			req.SetHeader(http.BCE_ACL, cannedAcl)
+		}
+	}
+	if len(grantRead) != 0 {
+		methods += 1
+		req.SetHeader(http.BCE_GRANT_READ, joiner(grantRead))
+	}
+	if len(grantFullControl) != 0 {
+		methods += 1
+		req.SetHeader(http.BCE_GRANT_FULL_CONTROL, joiner(grantFullControl))
+	}
+	if aclBody != nil {
+		methods += 1
+		req.SetHeader(http.CONTENT_TYPE, bce.DEFAULT_CONTENT_TYPE)
+		req.SetBody(aclBody)
+	}
+	if methods != 1 {
+		return bce.NewBceClientError("BOS only support one acl setting method at the same time")
+	}
+
+	// Do sending request
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}
+
+// GetObjectAcl - get the ACL of the given object
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - object: the object name
+// RETURNS:
+//     - result: the object acl result object
+//     - error: nil if success otherwise the specific error
+func GetObjectAcl(cli bce.Client, bucket, object string) (*GetObjectAclResult, error) {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.GET)
+	req.SetParam("acl", "")
+
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return nil, err
+	}
+	if resp.IsFail() {
+		return nil, resp.ServiceError()
+	}
+	result := &GetObjectAclResult{}
+	if err := resp.ParseJsonBody(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteObjectAcl - delete the ACL of the given object
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - object: the object name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func DeleteObjectAcl(cli bce.Client, bucket, object string) error {
+	req := &bce.BceRequest{}
+	req.SetUri(getObjectUri(bucket, object))
+	req.SetMethod(http.DELETE)
+	req.SetParam("acl", "")
+	resp := &bce.BceResponse{}
+	if err := cli.SendRequest(req, resp); err != nil {
+		return err
+	}
+	if resp.IsFail() {
+		return resp.ServiceError()
+	}
+	defer func() { resp.Body().Close() }()
+	return nil
+}

--- a/github.com/baidubce/bce-sdk-go/services/bos/api/util.go
+++ b/github.com/baidubce/bce-sdk-go/services/bos/api/util.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// util.go - define the utilities for api package of BOS service
+
+package api
+
+import (
+	"bytes"
+
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/http"
+)
+
+const (
+	METADATA_DIRECTIVE_COPY    = "copy"
+	METADATA_DIRECTIVE_REPLACE = "replace"
+
+	STORAGE_CLASS_STANDARD    = "STANDARD"
+	STORAGE_CLASS_STANDARD_IA = "STANDARD_IA"
+	STORAGE_CLASS_COLD        = "COLD"
+
+	FETCH_MODE_SYNC  = "sync"
+	FETCH_MODE_ASYNC = "async"
+
+	CANNED_ACL_PRIVATE           = "private"
+	CANNED_ACL_PUBLIC_READ       = "public-read"
+	CANNED_ACL_PUBLIC_READ_WRITE = "public-read-write"
+
+	RAW_CONTENT_TYPE = "application/octet-stream"
+
+	THRESHOLD_100_CONTINUE = 1 << 20 // add 100 continue header if body size bigger than 1MB
+
+	STATUS_ENABLED  = "enabled"
+	STATUS_DISABLED = "disabled"
+
+	ENCRYPTION_AES256 = "AES256"
+)
+
+var (
+	GET_OBJECT_ALLOWED_RESPONSE_HEADERS = map[string]struct{}{
+		"ContentDisposition": {},
+		"ContentType":        {},
+		"ContentLanguage":    {},
+		"Expires":            {},
+		"CacheControl":       {},
+		"ContentEncoding":    {},
+	}
+)
+
+func getBucketUri(bucketName string) string {
+	return bce.URI_PREFIX + bucketName
+}
+
+func getObjectUri(bucketName, objectName string) string {
+	return bce.URI_PREFIX + bucketName + "/" + objectName
+}
+
+func validMetadataDirective(val string) bool {
+	if val == METADATA_DIRECTIVE_COPY || val == METADATA_DIRECTIVE_REPLACE {
+		return true
+	}
+	return false
+}
+
+func validStorageClass(val string) bool {
+	if val == STORAGE_CLASS_STANDARD_IA ||
+		val == STORAGE_CLASS_STANDARD ||
+		val == STORAGE_CLASS_COLD {
+		return true
+	}
+	return false
+}
+
+func validFetchMode(val string) bool {
+	if val == FETCH_MODE_SYNC || val == FETCH_MODE_ASYNC {
+		return true
+	}
+	return false
+}
+
+func validCannedAcl(val string) bool {
+	if val == CANNED_ACL_PRIVATE ||
+		val == CANNED_ACL_PUBLIC_READ ||
+		val == CANNED_ACL_PUBLIC_READ_WRITE {
+		return true
+	}
+	return false
+}
+
+func toHttpHeaderKey(key string) string {
+	var result bytes.Buffer
+	needToUpper := true
+	for _, c := range []byte(key) {
+		if needToUpper && (c >= 'a' && c <= 'z') {
+			result.WriteByte(c - 32)
+			needToUpper = false
+		} else if c == '-' {
+			result.WriteByte(c)
+			needToUpper = true
+		} else {
+			result.WriteByte(c)
+		}
+	}
+	return result.String()
+}
+
+func setOptionalNullHeaders(req *bce.BceRequest, args map[string]string) {
+	for k, v := range args {
+		if len(v) == 0 {
+			continue
+		}
+		switch k {
+		case http.CACHE_CONTROL:
+			fallthrough
+		case http.CONTENT_DISPOSITION:
+			fallthrough
+		case http.CONTENT_ENCODING:
+			fallthrough
+		case http.CONTENT_RANGE:
+			fallthrough
+		case http.CONTENT_MD5:
+			fallthrough
+		case http.CONTENT_TYPE:
+			fallthrough
+		case http.EXPIRES:
+			fallthrough
+		case http.LAST_MODIFIED:
+			fallthrough
+		case http.ETAG:
+			fallthrough
+		case http.BCE_OBJECT_TYPE:
+			fallthrough
+		case http.BCE_NEXT_APPEND_OFFSET:
+			fallthrough
+		case http.BCE_CONTENT_SHA256:
+			fallthrough
+		case http.BCE_COPY_SOURCE_RANGE:
+			fallthrough
+		case http.BCE_COPY_SOURCE_IF_MATCH:
+			fallthrough
+		case http.BCE_COPY_SOURCE_IF_NONE_MATCH:
+			fallthrough
+		case http.BCE_COPY_SOURCE_IF_MODIFIED_SINCE:
+			fallthrough
+		case http.BCE_COPY_SOURCE_IF_UNMODIFIED_SINCE:
+			req.SetHeader(k, v)
+		}
+	}
+}
+
+func setUserMetadata(req *bce.BceRequest, meta map[string]string) error {
+	if meta == nil {
+		return nil
+	}
+	for k, v := range meta {
+		if len(k) == 0 {
+			continue
+		}
+		if len(k)+len(v) > 32*1024 {
+			return bce.NewBceClientError("MetadataTooLarge")
+		}
+		req.SetHeader(http.BCE_USER_METADATA_PREFIX+k, v)
+	}
+	return nil
+}

--- a/github.com/baidubce/bce-sdk-go/services/bos/client.go
+++ b/github.com/baidubce/bce-sdk-go/services/bos/client.go
@@ -1,0 +1,1681 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// client.go - define the client for BOS service
+
+// Package bos defines the BOS services of BCE. The supported APIs are all defined in sub-package
+// model with three types: 16 bucket APIs, 9 object APIs and 7 multipart APIs.
+package bos
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/baidubce/bce-sdk-go/auth"
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/services/bos/api"
+	"github.com/baidubce/bce-sdk-go/util/log"
+)
+
+const (
+	DEFAULT_SERVICE_DOMAIN = bce.DEFAULT_REGION + ".bcebos.com"
+	DEFAULT_MAX_PARALLEL   = 10
+	MULTIPART_ALIGN        = 1 << 20        // 1MB
+	MIN_MULTIPART_SIZE     = 1 << 20        // 1MB
+	DEFAULT_MULTIPART_SIZE = 10 * (1 << 20) // 10MB
+
+	MAX_PART_NUMBER        = 10000
+	MAX_SINGLE_PART_SIZE   = 5 * (1 << 30) // 5GB
+	MAX_SINGLE_OBJECT_SIZE = 5 * (1 << 40) // 5TB
+)
+
+// Client of BOS service is a kind of BceClient, so derived from BceClient
+type Client struct {
+	*bce.BceClient
+
+	// Fileds that used in parallel operation for BOS service
+	MaxParallel   int64
+	MultipartSize int64
+}
+
+// NewClient make the BOS service client with default configuration.
+// Use `cli.Config.xxx` to access the config or change it to non-default value.
+func NewClient(ak, sk, endpoint string) (*Client, error) {
+	var credentials *auth.BceCredentials
+	var err error
+	if len(ak) == 0 && len(sk) == 0 { // to support public-read-write request
+		credentials, err = nil, nil
+	} else {
+		credentials, err = auth.NewBceCredentials(ak, sk)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(endpoint) == 0 {
+		endpoint = DEFAULT_SERVICE_DOMAIN
+	}
+	defaultSignOptions := &auth.SignOptions{
+		HeadersToSign: auth.DEFAULT_HEADERS_TO_SIGN,
+		ExpireSeconds: auth.DEFAULT_EXPIRE_SECONDS}
+	defaultConf := &bce.BceClientConfiguration{
+		Endpoint:    endpoint,
+		Region:      bce.DEFAULT_REGION,
+		UserAgent:   bce.DEFAULT_USER_AGENT,
+		Credentials: credentials,
+		SignOption:  defaultSignOptions,
+		Retry:       bce.DEFAULT_RETRY_POLICY,
+		ConnectionTimeoutInMillis: bce.DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS}
+	v1Signer := &auth.BceV1Signer{}
+
+	client := &Client{bce.NewBceClient(defaultConf, v1Signer),
+		DEFAULT_MAX_PARALLEL, DEFAULT_MULTIPART_SIZE}
+	return client, nil
+}
+
+// ListBuckets - list all buckets
+//
+// RETURNS:
+//     - *api.ListBucketsResult: the all buckets
+//     - error: the return error if any occurs
+func (c *Client) ListBuckets() (*api.ListBucketsResult, error) {
+	return api.ListBuckets(c)
+}
+
+// ListObjects - list all objects of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - args: the optional arguments to list objects
+// RETURNS:
+//     - *api.ListObjectsResult: the all objects of the bucket
+//     - error: the return error if any occurs
+func (c *Client) ListObjects(bucket string,
+	args *api.ListObjectsArgs) (*api.ListObjectsResult, error) {
+	return api.ListObjects(c, bucket, args)
+}
+
+// SimpleListObjects - list all objects of the given bucket with simple arguments
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - prefix: the prefix for listing
+//     - maxKeys: the max number of result objects
+//     - marker: the marker to mark the beginning for the listing
+//     - delimiter: the delimiter for list objects
+// RETURNS:
+//     - *api.ListObjectsResult: the all objects of the bucket
+//     - error: the return error if any occurs
+func (c *Client) SimpleListObjects(bucket, prefix string, maxKeys int, marker,
+	delimiter string) (*api.ListObjectsResult, error) {
+	args := &api.ListObjectsArgs{delimiter, marker, maxKeys, prefix}
+	return api.ListObjects(c, bucket, args)
+}
+
+// HeadBucket - test the given bucket existed and access authority
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if exists and have authority otherwise the specific error
+func (c *Client) HeadBucket(bucket string) error {
+	return api.HeadBucket(c, bucket)
+}
+
+// DoesBucketExist - test the given bucket existed or not
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - bool: true if exists and false if not exists or occurs error
+//     - error: nil if exists or not exist, otherwise the specific error
+func (c *Client) DoesBucketExist(bucket string) (bool, error) {
+	err := api.HeadBucket(c, bucket)
+	if err == nil {
+		return true, nil
+	}
+	if realErr, ok := err.(*bce.BceServiceError); ok {
+		if realErr.StatusCode == http.StatusForbidden {
+			return true, nil
+		}
+		if realErr.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+	}
+	return false, err
+}
+
+// PutBucket - create a new bucket
+//
+// PARAMS:
+//     - bucket: the new bucket name
+// RETURNS:
+//     - string: the location of the new bucket if create success
+//     - error: nil if create success otherwise the specific error
+func (c *Client) PutBucket(bucket string) (string, error) {
+	return api.PutBucket(c, bucket)
+}
+
+// DeleteBucket - delete a empty bucket
+//
+// PARAMS:
+//     - bucket: the bucket name to be deleted
+// RETURNS:
+//     - error: nil if delete success otherwise the specific error
+func (c *Client) DeleteBucket(bucket string) error {
+	return api.DeleteBucket(c, bucket)
+}
+
+// GetBucketLocation - get the location fo the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - string: the location of the bucket
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketLocation(bucket string) (string, error) {
+	return api.GetBucketLocation(c, bucket)
+}
+
+// PutBucketAcl - set the acl of the given bucket with acl body stream
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - aclBody: the acl json body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketAcl(bucket string, aclBody *bce.Body) error {
+	return api.PutBucketAcl(c, bucket, "", aclBody)
+}
+
+// PutBucketAclFromCanned - set the canned acl of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - cannedAcl: the cannedAcl string
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketAclFromCanned(bucket, cannedAcl string) error {
+	return api.PutBucketAcl(c, bucket, cannedAcl, nil)
+}
+
+// PutBucketAclFromFile - set the acl of the given bucket with acl json file name
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - aclFile: the acl file name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketAclFromFile(bucket, aclFile string) error {
+	body, err := bce.NewBodyFromFile(aclFile)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketAcl(c, bucket, "", body)
+}
+
+// PutBucketAclFromString - set the acl of the given bucket with acl json string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - aclString: the acl string with json format
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketAclFromString(bucket, aclString string) error {
+	body, err := bce.NewBodyFromString(aclString)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketAcl(c, bucket, "", body)
+}
+
+// PutBucketAclFromStruct - set the acl of the given bucket with acl data structure
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - aclObj: the acl struct object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketAclFromStruct(bucket string, aclObj *api.PutBucketAclArgs) error {
+	jsonBytes, jsonErr := json.Marshal(aclObj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketAcl(c, bucket, "", body)
+}
+
+// GetBucketAcl - get the acl of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - *api.GetBucketAclResult: the result of the bucket acl
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketAcl(bucket string) (*api.GetBucketAclResult, error) {
+	return api.GetBucketAcl(c, bucket)
+}
+
+// PutBucketLogging - set the loging setting of the given bucket with json stream
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - body: the json body
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketLogging(bucket string, body *bce.Body) error {
+	return api.PutBucketLogging(c, bucket, body)
+}
+
+// PutBucketLoggingFromString - set the loging setting of the given bucket with json string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - logging: the json format string
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketLoggingFromString(bucket, logging string) error {
+	body, err := bce.NewBodyFromString(logging)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketLogging(c, bucket, body)
+}
+
+// PutBucketLoggingFromStruct - set the loging setting of the given bucket with args object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - obj: the logging setting object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketLoggingFromStruct(bucket string, obj *api.PutBucketLoggingArgs) error {
+	jsonBytes, jsonErr := json.Marshal(obj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketLogging(c, bucket, body)
+}
+
+// GetBucketLogging - get the logging setting of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - *api.GetBucketLoggingResult: the logging setting of the bucket
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketLogging(bucket string) (*api.GetBucketLoggingResult, error) {
+	return api.GetBucketLogging(c, bucket)
+}
+
+// DeleteBucketLogging - delete the logging setting of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketLogging(bucket string) error {
+	return api.DeleteBucketLogging(c, bucket)
+}
+
+// PutBucketLifecycle - set the lifecycle rule of the given bucket with raw stream
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - lifecycle: the lifecycle rule json body
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketLifecycle(bucket string, lifecycle *bce.Body) error {
+	return api.PutBucketLifecycle(c, bucket, lifecycle)
+}
+
+// PutBucketLifecycleFromString - set the lifecycle rule of the given bucket with string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - lifecycle: the lifecycle rule json format string body
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketLifecycleFromString(bucket, lifecycle string) error {
+	body, err := bce.NewBodyFromString(lifecycle)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketLifecycle(c, bucket, body)
+}
+
+// GetBucketLifecycle - get the lifecycle rule of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - *api.GetBucketLifecycleResult: the lifecycle rule of the bucket
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketLifecycle(bucket string) (*api.GetBucketLifecycleResult, error) {
+	return api.GetBucketLifecycle(c, bucket)
+}
+
+// DeleteBucketLifecycle - delete the lifecycle rule of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketLifecycle(bucket string) error {
+	return api.DeleteBucketLifecycle(c, bucket)
+}
+
+// PutBucketStorageclass - set the storage class of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - storageClass: the storage class string value
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketStorageclass(bucket, storageClass string) error {
+	return api.PutBucketStorageclass(c, bucket, storageClass)
+}
+
+// GetBucketStorageclass - get the storage class of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - string: the storage class string value
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketStorageclass(bucket string) (string, error) {
+	return api.GetBucketStorageclass(c, bucket)
+}
+
+// PutBucketReplication - set the bucket replication config of different region
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - replicationConf: the replication config json body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketReplication(bucket string, replicationConf *bce.Body) error {
+	return api.PutBucketReplication(c, bucket, replicationConf)
+}
+
+// PutBucketReplicationFromFile - set the bucket replication config with json file name
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - confFile: the config json file name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketReplicationFromFile(bucket, confFile string) error {
+	body, err := bce.NewBodyFromFile(confFile)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketReplication(c, bucket, body)
+}
+
+// PutBucketReplicationFromString - set the bucket replication config with json string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - confString: the config string with json format
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketReplicationFromString(bucket, confString string) error {
+	body, err := bce.NewBodyFromString(confString)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketReplication(c, bucket, body)
+}
+
+// PutBucketReplicationFromStruct - set the bucket replication config with struct
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - confObj: the replication config struct object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketReplicationFromStruct(bucket string,
+	confObj *api.PutBucketReplicationArgs) error {
+	jsonBytes, jsonErr := json.Marshal(confObj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketReplication(c, bucket, body)
+}
+
+// GetBucketReplication - get the bucket replication config of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - *api.GetBucketReplicationResult: the result of the bucket replication config
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketReplication(bucket string) (*api.GetBucketReplicationResult, error) {
+	return api.GetBucketReplication(c, bucket)
+}
+
+// DeleteBucketReplication - delete the bucket replication config of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketReplication(bucket string) error {
+	return api.DeleteBucketReplication(c, bucket)
+}
+
+// GetBucketReplicationProgress - get the bucket replication process of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - *api.GetBucketReplicationProgressResult: the process of the bucket replication
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketReplicationProgress(bucket string) (
+	*api.GetBucketReplicationProgressResult, error) {
+	return api.GetBucketReplicationProgress(c, bucket)
+}
+
+// PutBucketEncryption - set the bucket encryption config of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - algorithm: the encryption algorithm name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketEncryption(bucket, algorithm string) error {
+	return api.PutBucketEncryption(c, bucket, algorithm)
+}
+
+// GetBucketEncryption - get the bucket encryption config
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - string: the encryption algorithm name
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketEncryption(bucket string) (string, error) {
+	return api.GetBucketEncryption(c, bucket)
+}
+
+// DeleteBucketEncryption - delete the bucket encryption config of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketEncryption(bucket string) error {
+	return api.DeleteBucketEncryption(c, bucket)
+}
+
+// PutBucketStaticWebsite - set the bucket static website config
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - config: the static website config body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketStaticWebsite(bucket string, config *bce.Body) error {
+	return api.PutBucketStaticWebsite(c, bucket, config)
+}
+
+// PutBucketStaticWebsiteFromString - set the bucket static website config from json string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - jsonConfig: the static website config json string
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketStaticWebsiteFromString(bucket, jsonConfig string) error {
+	body, err := bce.NewBodyFromString(jsonConfig)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketStaticWebsite(c, bucket, body)
+}
+
+// PutBucketStaticWebsiteFromStruct - set the bucket static website config from struct
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - confObj: the static website config object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketStaticWebsiteFromStruct(bucket string,
+	confObj *api.PutBucketStaticWebsiteArgs) error {
+	jsonBytes, jsonErr := json.Marshal(confObj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketStaticWebsite(c, bucket, body)
+}
+
+// SimplePutBucketStaticWebsite - simple set the bucket static website config
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - index: the static website config for index file name
+//     - notFound: the static website config for notFound file name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) SimplePutBucketStaticWebsite(bucket, index, notFound string) error {
+	confObj := &api.PutBucketStaticWebsiteArgs{index, notFound}
+	return c.PutBucketStaticWebsiteFromStruct(bucket, confObj)
+}
+
+// GetBucketStaticWebsite - get the bucket static website config
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - result: the static website config result object
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketStaticWebsite(bucket string) (
+	*api.GetBucketStaticWebsiteResult, error) {
+	return api.GetBucketStaticWebsite(c, bucket)
+}
+
+// DeleteBucketStaticWebsite - delete the bucket static website config of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketStaticWebsite(bucket string) error {
+	return api.DeleteBucketStaticWebsite(c, bucket)
+}
+
+// PutBucketCors - set the bucket CORS config
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - config: the bucket CORS config body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketCors(bucket string, config *bce.Body) error {
+	return api.PutBucketCors(c, bucket, config)
+}
+
+// PutBucketCorsFromFile - set the bucket CORS config from json config file
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - filename: the bucket CORS json config file name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketCorsFromFile(bucket, filename string) error {
+	body, err := bce.NewBodyFromFile(filename)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketCors(c, bucket, body)
+}
+
+// PutBucketCorsFromString - set the bucket CORS config from json config string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - filename: the bucket CORS json config string
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketCorsFromString(bucket, jsonConfig string) error {
+	body, err := bce.NewBodyFromString(jsonConfig)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketCors(c, bucket, body)
+}
+
+// PutBucketCorsFromStruct - set the bucket CORS config from json config object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - filename: the bucket CORS json config object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketCorsFromStruct(bucket string, confObj *api.PutBucketCorsArgs) error {
+	jsonBytes, jsonErr := json.Marshal(confObj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return api.PutBucketCors(c, bucket, body)
+}
+
+// GetBucketCors - get the bucket CORS config
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - result: the bucket CORS config result object
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketCors(bucket string) (*api.GetBucketCorsResult, error) {
+	return api.GetBucketCors(c, bucket)
+}
+
+// DeleteBucketCors - delete the bucket CORS config of the given bucket
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketCors(bucket string) error {
+	return api.DeleteBucketCors(c, bucket)
+}
+
+// PutBucketCopyrightProtection - set the copyright protection config of the given bucket
+//
+// PARAMS:
+//     - cli: the client agent which can perform sending request
+//     - bucket: the bucket name
+//     - resources: the resource items in the bucket to be protected
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutBucketCopyrightProtection(bucket string, resources ...string) error {
+	return api.PutBucketCopyrightProtection(c, bucket, resources...)
+}
+
+// GetBucketCopyrightProtection - get the bucket copyright protection config
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - result: the bucket copyright protection config resources
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetBucketCopyrightProtection(bucket string) ([]string, error) {
+	return api.GetBucketCopyrightProtection(c, bucket)
+}
+
+// DeleteBucketCopyrightProtection - delete the bucket copyright protection config
+//
+// PARAMS:
+//     - bucket: the bucket name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteBucketCopyrightProtection(bucket string) error {
+	return api.DeleteBucketCopyrightProtection(c, bucket)
+}
+
+// PutObject - upload a new object or rewrite the existed object with raw stream
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store the object
+//     - object: the name of the object
+//     - body: the object content body
+//     - args: the optional arguments
+// RETURNS:
+//     - string: etag of the uploaded object
+//     - error: the uploaded error if any occurs
+func (c *Client) PutObject(bucket, object string, body *bce.Body,
+	args *api.PutObjectArgs) (string, error) {
+	return api.PutObject(c, bucket, object, body, args)
+}
+
+// BasicPutObject - the basic interface of uploading an object
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store the object
+//     - object: the name of the object
+//     - body: the object content body
+// RETURNS:
+//     - string: etag of the uploaded object
+//     - error: the uploaded error if any occurs
+func (c *Client) BasicPutObject(bucket, object string, body *bce.Body) (string, error) {
+	return api.PutObject(c, bucket, object, body, nil)
+}
+
+// PutObjectFromBytes - upload a new object or rewrite the existed object from a byte array
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store the object
+//     - object: the name of the object
+//     - bytesArr: the content byte array
+//     - args: the optional arguments
+// RETURNS:
+//     - string: etag of the uploaded object
+//     - error: the uploaded error if any occurs
+func (c *Client) PutObjectFromBytes(bucket, object string, bytesArr []byte,
+	args *api.PutObjectArgs) (string, error) {
+	body, err := bce.NewBodyFromBytes(bytesArr)
+	if err != nil {
+		return "", err
+	}
+	return api.PutObject(c, bucket, object, body, args)
+}
+
+// PutObjectFromString - upload a new object or rewrite the existed object from a string
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store the object
+//     - object: the name of the object
+//     - content: the content string
+//     - args: the optional arguments
+// RETURNS:
+//     - string: etag of the uploaded object
+//     - error: the uploaded error if any occurs
+func (c *Client) PutObjectFromString(bucket, object, content string,
+	args *api.PutObjectArgs) (string, error) {
+	body, err := bce.NewBodyFromString(content)
+	if err != nil {
+		return "", err
+	}
+	return api.PutObject(c, bucket, object, body, args)
+}
+
+// PutObjectFromFile - upload a new object or rewrite the existed object from a local file
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store the object
+//     - object: the name of the object
+//     - fileName: the local file full path name
+//     - args: the optional arguments
+// RETURNS:
+//     - string: etag of the uploaded object
+//     - error: the uploaded error if any occurs
+func (c *Client) PutObjectFromFile(bucket, object, fileName string,
+	args *api.PutObjectArgs) (string, error) {
+	body, err := bce.NewBodyFromFile(fileName)
+	if err != nil {
+		return "", err
+	}
+	return api.PutObject(c, bucket, object, body, args)
+}
+
+// CopyObject - copy a remote object to another one
+//
+// PARAMS:
+//     - bucket: the name of the destination bucket
+//     - object: the name of the destination object
+//     - srcBucket: the name of the source bucket
+//     - srcObject: the name of the source object
+//     - args: the optional arguments for copying object which are MetadataDirective, StorageClass,
+//       IfMatch, IfNoneMatch, ifModifiedSince, IfUnmodifiedSince
+// RETURNS:
+//     - *api.CopyObjectResult: result struct which contains "ETag" and "LastModified" fields
+//     - error: any error if it occurs
+func (c *Client) CopyObject(bucket, object, srcBucket, srcObject string,
+	args *api.CopyObjectArgs) (*api.CopyObjectResult, error) {
+	source := fmt.Sprintf("/%s/%s", srcBucket, srcObject)
+	return api.CopyObject(c, bucket, object, source, args)
+}
+
+// BasicCopyObject - the basic interface of copying a object to another one
+//
+// PARAMS:
+//     - bucket: the name of the destination bucket
+//     - object: the name of the destination object
+//     - srcBucket: the name of the source bucket
+//     - srcObject: the name of the source object
+// RETURNS:
+//     - *api.CopyObjectResult: result struct which contains "ETag" and "LastModified" fields
+//     - error: any error if it occurs
+func (c *Client) BasicCopyObject(bucket, object, srcBucket,
+	srcObject string) (*api.CopyObjectResult, error) {
+	source := fmt.Sprintf("/%s/%s", srcBucket, srcObject)
+	return api.CopyObject(c, bucket, object, source, nil)
+}
+
+// GetObject - get the given object with raw stream return
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+//     - responseHeaders: the optional response headers to get the given object
+//     - ranges: the optional range start and end to get the given object
+// RETURNS:
+//     - *api.GetObjectResult: result struct which contains "Body" and header fields
+//       for details reference https://cloud.baidu.com/doc/BOS/API.html#GetObject.E6.8E.A5.E5.8F.A3
+//     - error: any error if it occurs
+func (c *Client) GetObject(bucket, object string, responseHeaders map[string]string,
+	ranges ...int64) (*api.GetObjectResult, error) {
+	return api.GetObject(c, bucket, object, responseHeaders, ranges...)
+}
+
+// BasicGetObject - the basic interface of geting the given object
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+// RETURNS:
+//     - *api.GetObjectResult: result struct which contains "Body" and header fields
+//       for details reference https://cloud.baidu.com/doc/BOS/API.html#GetObject.E6.8E.A5.E5.8F.A3
+//     - error: any error if it occurs
+func (c *Client) BasicGetObject(bucket, object string) (*api.GetObjectResult, error) {
+	return api.GetObject(c, bucket, object, nil)
+}
+
+// BasicGetObjectToFile - use basic interface to get the given object to the given file path
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+//     - filePath: the file path to store the object content
+// RETURNS:
+//     - error: any error if it occurs
+func (c *Client) BasicGetObjectToFile(bucket, object, filePath string) error {
+	res, err := api.GetObject(c, bucket, object, nil)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	file, fileErr := os.OpenFile(filePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	if fileErr != nil {
+		return fileErr
+	}
+	defer file.Close()
+
+	written, writeErr := io.CopyN(file, res.Body, res.ContentLength)
+	if writeErr != nil {
+		return writeErr
+	}
+	if written != res.ContentLength {
+		return fmt.Errorf("written content size does not match the response content")
+	}
+	return nil
+}
+
+// GetObjectMeta - get the given object metadata
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+// RETURNS:
+//     - *api.GetObjectMetaResult: metadata result, for details reference
+//       https://cloud.baidu.com/doc/BOS/API.html#GetObjectMeta.E6.8E.A5.E5.8F.A3
+//     - error: any error if it occurs
+func (c *Client) GetObjectMeta(bucket, object string) (*api.GetObjectMetaResult, error) {
+	return api.GetObjectMeta(c, bucket, object)
+}
+
+// FetchObject - fetch the object content from the given source and store
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store
+//     - object: the name of the object to store
+//     - source: fetch source url
+//     - args: the optional arguments to fetch the object
+// RETURNS:
+//     - *api.FetchObjectResult: result struct with Code, Message, RequestId and JobId fields
+//     - error: any error if it occurs
+func (c *Client) FetchObject(bucket, object, source string,
+	args *api.FetchObjectArgs) (*api.FetchObjectResult, error) {
+	return api.FetchObject(c, bucket, object, source, args)
+}
+
+// BasicFetchObject - the basic interface of the fetch object api
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store
+//     - object: the name of the object to store
+//     - source: fetch source url
+// RETURNS:
+//     - *api.FetchObjectResult: result struct with Code, Message, RequestId and JobId fields
+//     - error: any error if it occurs
+func (c *Client) BasicFetchObject(bucket, object, source string) (*api.FetchObjectResult, error) {
+	return api.FetchObject(c, bucket, object, source, nil)
+}
+
+// SimpleFetchObject - fetch object with simple arguments interface
+//
+// PARAMS:
+//     - bucket: the name of the bucket to store
+//     - object: the name of the object to store
+//     - source: fetch source url
+//     - mode: fetch mode which supports sync and async
+//     - storageClass: the storage class of the fetched object
+// RETURNS:
+//     - *api.FetchObjectResult: result struct with Code, Message, RequestId and JobId fields
+//     - error: any error if it occurs
+func (c *Client) SimpleFetchObject(bucket, object, source, mode,
+	storageClass string) (*api.FetchObjectResult, error) {
+	args := &api.FetchObjectArgs{mode, storageClass}
+	return api.FetchObject(c, bucket, object, source, args)
+}
+
+// AppendObject - append the given content to a new or existed object which is appendable
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+//     - content: the append object stream
+//     - args: the optional arguments to append object
+// RETURNS:
+//     - *api.AppendObjectResult: the result of the appended object
+//     - error: any error if it occurs
+func (c *Client) AppendObject(bucket, object string, content *bce.Body,
+	args *api.AppendObjectArgs) (*api.AppendObjectResult, error) {
+	return api.AppendObject(c, bucket, object, content, args)
+}
+
+// SimpleAppendObject - the interface to append object with simple offset argument
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+//     - content: the append object stream
+//     - offset: the offset of where to append
+// RETURNS:
+//     - *api.AppendObjectResult: the result of the appended object
+//     - error: any error if it occurs
+func (c *Client) SimpleAppendObject(bucket, object string, content *bce.Body,
+	offset int64) (*api.AppendObjectResult, error) {
+	return api.AppendObject(c, bucket, object, content, &api.AppendObjectArgs{Offset: offset})
+}
+
+// SimpleAppendObjectFromString - the simple interface of appending an object from a string
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+//     - content: the object string to append
+//     - offset: the offset of where to append
+// RETURNS:
+//     - *api.AppendObjectResult: the result of the appended object
+//     - error: any error if it occurs
+func (c *Client) SimpleAppendObjectFromString(bucket, object, content string,
+	offset int64) (*api.AppendObjectResult, error) {
+	body, err := bce.NewBodyFromString(content)
+	if err != nil {
+		return nil, err
+	}
+	return api.AppendObject(c, bucket, object, body, &api.AppendObjectArgs{Offset: offset})
+}
+
+// SimpleAppendObjectFromFile - the simple interface of appending an object from a file
+//
+// PARAMS:
+//     - bucket: the name of the bucket
+//     - object: the name of the object
+//     - filePath: the full file path
+//     - offset: the offset of where to append
+// RETURNS:
+//     - *api.AppendObjectResult: the result of the appended object
+//     - error: any error if it occurs
+func (c *Client) SimpleAppendObjectFromFile(bucket, object, filePath string,
+	offset int64) (*api.AppendObjectResult, error) {
+	body, err := bce.NewBodyFromFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return api.AppendObject(c, bucket, object, body, &api.AppendObjectArgs{Offset: offset})
+}
+
+// DeleteObject - delete the given object
+//
+// PARAMS:
+//     - bucket: the name of the bucket to delete
+//     - object: the name of the object to delete
+// RETURNS:
+//     - error: any error if it occurs
+func (c *Client) DeleteObject(bucket, object string) error {
+	return api.DeleteObject(c, bucket, object)
+}
+
+// DeleteMultipleObjects - delete a list of objects
+//
+// PARAMS:
+//     - bucket: the name of the bucket to delete
+//     - objectListStream: the object list stream to be deleted
+// RETURNS:
+//     - *api.DeleteMultipleObjectsResult: the delete information
+//     - error: any error if it occurs
+func (c *Client) DeleteMultipleObjects(bucket string,
+	objectListStream *bce.Body) (*api.DeleteMultipleObjectsResult, error) {
+	return api.DeleteMultipleObjects(c, bucket, objectListStream)
+}
+
+// DeleteMultipleObjectsFromString - delete a list of objects with json format string
+//
+// PARAMS:
+//     - bucket: the name of the bucket to delete
+//     - objectListString: the object list string to be deleted
+// RETURNS:
+//     - *api.DeleteMultipleObjectsResult: the delete information
+//     - error: any error if it occurs
+func (c *Client) DeleteMultipleObjectsFromString(bucket,
+	objectListString string) (*api.DeleteMultipleObjectsResult, error) {
+	body, err := bce.NewBodyFromString(objectListString)
+	if err != nil {
+		return nil, err
+	}
+	return api.DeleteMultipleObjects(c, bucket, body)
+}
+
+// DeleteMultipleObjectsFromStruct - delete a list of objects with object list struct
+//
+// PARAMS:
+//     - bucket: the name of the bucket to delete
+//     - objectListStruct: the object list struct to be deleted
+// RETURNS:
+//     - *api.DeleteMultipleObjectsResult: the delete information
+//     - error: any error if it occurs
+func (c *Client) DeleteMultipleObjectsFromStruct(bucket string,
+	objectListStruct *api.DeleteMultipleObjectsArgs) (*api.DeleteMultipleObjectsResult, error) {
+	jsonBytes, jsonErr := json.Marshal(objectListStruct)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return nil, err
+	}
+	return api.DeleteMultipleObjects(c, bucket, body)
+}
+
+// DeleteMultipleObjectsFromKeyList - delete a list of objects with given key string array
+//
+// PARAMS:
+//     - bucket: the name of the bucket to delete
+//     - keyList: the key string list to be deleted
+// RETURNS:
+//     - *api.DeleteMultipleObjectsResult: the delete information
+//     - error: any error if it occurs
+func (c *Client) DeleteMultipleObjectsFromKeyList(bucket string,
+	keyList []string) (*api.DeleteMultipleObjectsResult, error) {
+	if len(keyList) == 0 {
+		return nil, fmt.Errorf("the key list to be deleted is empty")
+	}
+	args := make([]api.DeleteObjectArgs, len(keyList))
+	for i, k := range keyList {
+		args[i].Key = k
+	}
+	argsContainer := &api.DeleteMultipleObjectsArgs{args}
+
+	jsonBytes, jsonErr := json.Marshal(argsContainer)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return nil, err
+	}
+	return api.DeleteMultipleObjects(c, bucket, body)
+}
+
+// InitiateMultipartUpload - initiate a multipart upload to get a upload ID
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - contentType: the content type of the object to be uploaded which should be specified,
+//       otherwise use the default(application/octet-stream)
+//     - args: the optional arguments
+// RETURNS:
+//     - *InitiateMultipartUploadResult: the result data structure
+//     - error: nil if ok otherwise the specific error
+func (c *Client) InitiateMultipartUpload(bucket, object, contentType string,
+	args *api.InitiateMultipartUploadArgs) (*api.InitiateMultipartUploadResult, error) {
+	return api.InitiateMultipartUpload(c, bucket, object, contentType, args)
+}
+
+// BasicInitiateMultipartUpload - basic interface to initiate a multipart upload
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+// RETURNS:
+//     - *InitiateMultipartUploadResult: the result data structure
+//     - error: nil if ok otherwise the specific error
+func (c *Client) BasicInitiateMultipartUpload(bucket,
+	object string) (*api.InitiateMultipartUploadResult, error) {
+	return api.InitiateMultipartUpload(c, bucket, object, "", nil)
+}
+
+// UploadPart - upload the single part in the multipart upload process
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - uploadId: the multipart upload id
+//     - partNumber: the current part number
+//     - content: the uploaded part content
+//     - args: the optional arguments
+// RETURNS:
+//     - string: the etag of the uploaded part
+//     - error: nil if ok otherwise the specific error
+func (c *Client) UploadPart(bucket, object, uploadId string, partNumber int,
+	content *bce.Body, args *api.UploadPartArgs) (string, error) {
+	return api.UploadPart(c, bucket, object, uploadId, partNumber, content, args)
+}
+
+// BasicUploadPart - basic interface to upload the single part in the multipart upload process
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - uploadId: the multipart upload id
+//     - partNumber: the current part number
+//     - content: the uploaded part content
+// RETURNS:
+//     - string: the etag of the uploaded part
+//     - error: nil if ok otherwise the specific error
+func (c *Client) BasicUploadPart(bucket, object, uploadId string, partNumber int,
+	content *bce.Body) (string, error) {
+	return api.UploadPart(c, bucket, object, uploadId, partNumber, content, nil)
+}
+
+// UploadPartCopy - copy the multipart object
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - srcBucket: the source bucket
+//     - srcObject: the source object
+//     - uploadId: the multipart upload id
+//     - partNumber: the current part number
+//     - args: the optional arguments
+// RETURNS:
+//     - *CopyObjectResult: the lastModified and eTag of the part
+//     - error: nil if ok otherwise the specific error
+func (c *Client) UploadPartCopy(bucket, object, srcBucket, srcObject, uploadId string,
+	partNumber int, args *api.UploadPartCopyArgs) (*api.CopyObjectResult, error) {
+	source := fmt.Sprintf("/%s/%s", srcBucket, srcObject)
+	return api.UploadPartCopy(c, bucket, object, source, uploadId, partNumber, args)
+}
+
+// BasicUploadPartCopy - basic interface to copy the multipart object
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - srcBucket: the source bucket
+//     - srcObject: the source object
+//     - uploadId: the multipart upload id
+//     - partNumber: the current part number
+// RETURNS:
+//     - *CopyObjectResult: the lastModified and eTag of the part
+//     - error: nil if ok otherwise the specific error
+func (c *Client) BasicUploadPartCopy(bucket, object, srcBucket, srcObject, uploadId string,
+	partNumber int) (*api.CopyObjectResult, error) {
+	source := fmt.Sprintf("/%s/%s", srcBucket, srcObject)
+	return api.UploadPartCopy(c, bucket, object, source, uploadId, partNumber, nil)
+}
+
+// CompleteMultipartUpload - finish a multipart upload operation with parts stream
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+//     - parts: all parts info stream
+//     - meta: user defined meta data
+// RETURNS:
+//     - *CompleteMultipartUploadResult: the result data
+//     - error: nil if ok otherwise the specific error
+func (c *Client) CompleteMultipartUpload(bucket, object, uploadId string,
+	parts *bce.Body, meta map[string]string) (*api.CompleteMultipartUploadResult, error) {
+	return api.CompleteMultipartUpload(c, bucket, object, uploadId, parts, meta)
+}
+
+// CompleteMultipartUploadFromStruct - finish a multipart upload operation with parts struct
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+//     - parts: all parts info struct object
+//     - meta: user defined meta data
+// RETURNS:
+//     - *CompleteMultipartUploadResult: the result data
+//     - error: nil if ok otherwise the specific error
+func (c *Client) CompleteMultipartUploadFromStruct(bucket, object, uploadId string,
+	parts *api.CompleteMultipartUploadArgs,
+	meta map[string]string) (*api.CompleteMultipartUploadResult, error) {
+	jsonBytes, jsonErr := json.Marshal(parts)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return nil, err
+	}
+	return api.CompleteMultipartUpload(c, bucket, object, uploadId, body, meta)
+}
+
+// AbortMultipartUpload - abort a multipart upload operation
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+// RETURNS:
+//     - error: nil if ok otherwise the specific error
+func (c *Client) AbortMultipartUpload(bucket, object, uploadId string) error {
+	return api.AbortMultipartUpload(c, bucket, object, uploadId)
+}
+
+// ListParts - list the successfully uploaded parts info by upload id
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+//     - args: the optional arguments
+// RETURNS:
+//     - *ListPartsResult: the uploaded parts info result
+//     - error: nil if ok otherwise the specific error
+func (c *Client) ListParts(bucket, object, uploadId string,
+	args *api.ListPartsArgs) (*api.ListPartsResult, error) {
+	return api.ListParts(c, bucket, object, uploadId, args)
+}
+
+// BasicListParts - basic interface to list the successfully uploaded parts info by upload id
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - uploadId: the multipart upload id
+// RETURNS:
+//     - *ListPartsResult: the uploaded parts info result
+//     - error: nil if ok otherwise the specific error
+func (c *Client) BasicListParts(bucket, object, uploadId string) (*api.ListPartsResult, error) {
+	return api.ListParts(c, bucket, object, uploadId, nil)
+}
+
+// ListMultipartUploads - list the unfinished uploaded parts of the given bucket
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - args: the optional arguments
+// RETURNS:
+//     - *ListMultipartUploadsResult: the unfinished uploaded parts info result
+//     - error: nil if ok otherwise the specific error
+func (c *Client) ListMultipartUploads(bucket string,
+	args *api.ListMultipartUploadsArgs) (*api.ListMultipartUploadsResult, error) {
+	return api.ListMultipartUploads(c, bucket, args)
+}
+
+// BasicListMultipartUploads - basic interface to list the unfinished uploaded parts
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+// RETURNS:
+//     - *ListMultipartUploadsResult: the unfinished uploaded parts info result
+//     - error: nil if ok otherwise the specific error
+func (c *Client) BasicListMultipartUploads(bucket string) (
+	*api.ListMultipartUploadsResult, error) {
+	return api.ListMultipartUploads(c, bucket, nil)
+}
+
+// UploadSuperFile - parallel upload the super file by using the multipart upload interface
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - fileName: the local full path filename of the super file
+//     - storageClass: the storage class to be set to the uploaded file
+// RETURNS:
+//     - error: nil if ok otherwise the specific error
+func (c *Client) UploadSuperFile(bucket, object, fileName, storageClass string) error {
+	// Get the file size and check the size for multipart upload
+	file, fileErr := os.Open(fileName)
+	if fileErr != nil {
+		return fileErr
+	}
+	oldTimeout := c.Config.ConnectionTimeoutInMillis
+	c.Config.ConnectionTimeoutInMillis = 0
+	defer func() {
+		c.Config.ConnectionTimeoutInMillis = oldTimeout
+		file.Close()
+	}()
+	fileInfo, infoErr := file.Stat()
+	if infoErr != nil {
+		return infoErr
+	}
+	size := fileInfo.Size()
+	if size < MIN_MULTIPART_SIZE || c.MultipartSize < MIN_MULTIPART_SIZE {
+		return bce.NewBceClientError("multipart size should not be less than 1MB")
+	}
+
+	// Calculate part size and total part number
+	partSize := (c.MultipartSize + MULTIPART_ALIGN - 1) / MULTIPART_ALIGN * MULTIPART_ALIGN
+	partNum := (size + partSize - 1) / partSize
+	if partNum > MAX_PART_NUMBER {
+		partSize = (size + MAX_PART_NUMBER - 1) / MAX_PART_NUMBER
+		partSize = (partSize + MULTIPART_ALIGN - 1) / MULTIPART_ALIGN * MULTIPART_ALIGN
+		partNum = (size + partSize - 1) / partSize
+	}
+	log.Debugf("starting upload super file, total parts: %d, part size: %d", partNum, partSize)
+
+	// Inner wrapper function of parallel uploading each part to get the ETag of the part
+	uploadPart := func(bucket, object, uploadId string, partNumber int, body *bce.Body,
+		result chan *api.UploadInfoType, ret chan error, id int64, pool chan int64) {
+		etag, err := c.BasicUploadPart(bucket, object, uploadId, partNumber, body)
+		if err != nil {
+			result <- nil
+			ret <- err
+		} else {
+			result <- &api.UploadInfoType{partNumber, etag}
+		}
+		pool <- id
+	}
+
+	// Do the parallel multipart upload
+	resp, err := c.InitiateMultipartUpload(bucket, object, "",
+		&api.InitiateMultipartUploadArgs{StorageClass: storageClass})
+	if err != nil {
+		return err
+	}
+	uploadId := resp.UploadId
+	uploadedResult := make(chan *api.UploadInfoType, partNum)
+	retChan := make(chan error, partNum)
+	workerPool := make(chan int64, c.MaxParallel)
+	for i := int64(0); i < c.MaxParallel; i++ {
+		workerPool <- i
+	}
+	for partId := int64(1); partId <= partNum; partId++ {
+		uploadSize := partSize
+		offset := (partId - 1) * partSize
+		left := size - offset
+		if uploadSize > left {
+			uploadSize = left
+		}
+		partBody, _ := bce.NewBodyFromSectionFile(file, offset, uploadSize)
+		select { // wait until get a worker to upload
+		case workerId := <-workerPool:
+			go uploadPart(bucket, object, uploadId, int(partId), partBody,
+				uploadedResult, retChan, workerId, workerPool)
+		case uploadPartErr := <-retChan:
+			c.AbortMultipartUpload(bucket, object, uploadId)
+			return uploadPartErr
+		}
+	}
+
+	// Check the return of each part uploading, and decide to complete or abort it
+	completeArgs := &api.CompleteMultipartUploadArgs{make([]api.UploadInfoType, partNum)}
+	for i := partNum; i > 0; i-- {
+		uploaded := <-uploadedResult
+		if uploaded == nil { // error occurs and not be caught in `select' statement
+			c.AbortMultipartUpload(bucket, object, uploadId)
+			return <-retChan
+		}
+		completeArgs.Parts[uploaded.PartNumber-1] = *uploaded
+		log.Debugf("upload part %d success, etag: %s", uploaded.PartNumber, uploaded.ETag)
+	}
+	if _, err := c.CompleteMultipartUploadFromStruct(bucket, object,
+		uploadId, completeArgs, nil); err != nil {
+		c.AbortMultipartUpload(bucket, object, uploadId)
+		return err
+	}
+	return nil
+}
+
+// DownloadSuperFile - parallel download the super file using the get object with range
+//
+// PARAMS:
+//     - bucket: the destination bucket name
+//     - object: the destination object name
+//     - fileName: the local full path filename to store the object
+// RETURNS:
+//     - error: nil if ok otherwise the specific error
+func (c *Client) DownloadSuperFile(bucket, object, fileName string) (err error) {
+	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	if err != nil {
+		return
+	}
+	oldTimeout := c.Config.ConnectionTimeoutInMillis
+	c.Config.ConnectionTimeoutInMillis = 0
+	defer func() {
+		c.Config.ConnectionTimeoutInMillis = oldTimeout
+		file.Close()
+		if err != nil {
+			os.Remove(fileName)
+		}
+	}()
+
+	meta, err := c.GetObjectMeta(bucket, object)
+	if err != nil {
+		return
+	}
+	size := meta.ContentLength
+	partSize := (c.MultipartSize + MULTIPART_ALIGN - 1) / MULTIPART_ALIGN * MULTIPART_ALIGN
+	partNum := (size + partSize - 1) / partSize
+	log.Debugf("starting download super file, total parts: %d, part size: %d", partNum, partSize)
+
+	doneChan := make(chan struct{}, partNum)
+	abortChan := make(chan struct{})
+
+	// Set up multiple goroutine workers to download the object
+	workerPool := make(chan int64, c.MaxParallel)
+	for i := int64(0); i < c.MaxParallel; i++ {
+		workerPool <- i
+	}
+	for i := int64(0); i < partNum; i++ {
+		rangeStart := i * partSize
+		rangeEnd := (i+1)*partSize - 1
+		if rangeEnd > size-1 {
+			rangeEnd = size - 1
+		}
+		select {
+		case workerId := <-workerPool:
+			go func(rangeStart, rangeEnd, workerId int64) {
+				res, rangeGetErr := c.GetObject(bucket, object, nil, rangeStart, rangeEnd)
+				if rangeGetErr != nil {
+					log.Errorf("download object part(offset:%d, size:%d) failed: %v",
+						rangeStart, res.ContentLength, rangeGetErr)
+					abortChan <- struct{}{}
+					err = rangeGetErr
+					return
+				}
+				defer res.Body.Close()
+				log.Debugf("writing part %d with offset=%d, size=%d", rangeStart/partSize,
+					rangeStart, res.ContentLength)
+				buf := make([]byte, 4096)
+				offset := rangeStart
+				for {
+					n, e := res.Body.Read(buf)
+					if e != nil && e != io.EOF {
+						abortChan <- struct{}{}
+						err = e
+						return
+					}
+					if n == 0 {
+						break
+					}
+					if _, writeErr := file.WriteAt(buf[:n], offset); writeErr != nil {
+						abortChan <- struct{}{}
+						err = writeErr
+						return
+					}
+					offset += int64(n)
+				}
+				log.Debugf("writing part %d done", rangeStart/partSize)
+				workerPool <- workerId
+				doneChan <- struct{}{}
+			}(rangeStart, rangeEnd, workerId)
+		case <-abortChan: // abort range get if error occurs during downloading any part
+			return
+		}
+	}
+
+	// Wait for writing to local file done
+	for i := partNum; i > 0; i-- {
+		<-doneChan
+	}
+	return nil
+}
+
+// GeneratePresignedUrl - generate an authorization url with expire time and optional arguments
+//
+// PARAMS:
+//     - bucket: the target bucket name
+//     - object: the target object name
+//     - expireInSeconds: the expire time in seconds of the signed url
+//     - method: optional sign method, default is GET
+//     - headers: optional sign headers, default just set the Host
+//     - params: optional sign params, default is empty
+// RETURNS:
+//     - string: the presigned url with authorization string
+func (c *Client) GeneratePresignedUrl(bucket, object string, expireInSeconds int, method string,
+	headers, params map[string]string) string {
+	return api.GeneratePresignedUrl(c.Config, c.Signer, bucket, object,
+		expireInSeconds, method, headers, params)
+}
+
+// BasicGeneratePresignedUrl - basic interface to generate an authorization url with expire time
+//
+// PARAMS:
+//     - bucket: the target bucket name
+//     - object: the target object name
+//     - expireInSeconds: the expire time in seconds of the signed url
+// RETURNS:
+//     - string: the presigned url with authorization string
+func (c *Client) BasicGeneratePresignedUrl(bucket, object string, expireInSeconds int) string {
+	return api.GeneratePresignedUrl(c.Config, c.Signer, bucket, object,
+		expireInSeconds, "", nil, nil)
+}
+
+// PutObjectAcl - set the ACL of the given object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - aclBody: the acl json body stream
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAcl(bucket, object string, aclBody *bce.Body) error {
+	return api.PutObjectAcl(c, bucket, object, "", nil, nil, aclBody)
+}
+
+// PutObjectAclFromCanned - set the canned acl of the given object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - cannedAcl: the cannedAcl string
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAclFromCanned(bucket, object, cannedAcl string) error {
+	return api.PutObjectAcl(c, bucket, object, cannedAcl, nil, nil, nil)
+}
+
+// PutObjectAclGrantRead - set the canned grant read acl of the given object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - ids: the user id list to grant read for this object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAclGrantRead(bucket, object string, ids ...string) error {
+	return api.PutObjectAcl(c, bucket, object, "", ids, nil, nil)
+}
+
+// PutObjectAclGrantFullControl - set the canned grant full-control acl of the given object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - ids: the user id list to grant full-control for this object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAclGrantFullControl(bucket, object string, ids ...string) error {
+	return api.PutObjectAcl(c, bucket, object, "", nil, ids, nil)
+}
+
+// PutObjectAclFromFile - set the acl of the given object with acl json file name
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - aclFile: the acl file name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAclFromFile(bucket, object, aclFile string) error {
+	body, err := bce.NewBodyFromFile(aclFile)
+	if err != nil {
+		return err
+	}
+	return api.PutObjectAcl(c, bucket, object, "", nil, nil, body)
+}
+
+// PutObjectAclFromString - set the acl of the given object with acl json string
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+//     - aclString: the acl string with json format
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAclFromString(bucket, object, aclString string) error {
+	body, err := bce.NewBodyFromString(aclString)
+	if err != nil {
+		return err
+	}
+	return api.PutObjectAcl(c, bucket, object, "", nil, nil, body)
+}
+
+// PutObjectAclFromStruct - set the acl of the given object with acl data structure
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - aclObj: the acl struct object
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) PutObjectAclFromStruct(bucket, object string, aclObj *api.PutObjectAclArgs) error {
+	jsonBytes, jsonErr := json.Marshal(aclObj)
+	if jsonErr != nil {
+		return jsonErr
+	}
+	body, err := bce.NewBodyFromBytes(jsonBytes)
+	if err != nil {
+		return err
+	}
+	return api.PutObjectAcl(c, bucket, object, "", nil, nil, body)
+}
+
+// GetObjectAcl - get the acl of the given object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+// RETURNS:
+//     - *api.GetObjectAclResult: the result of the object acl
+//     - error: nil if success otherwise the specific error
+func (c *Client) GetObjectAcl(bucket, object string) (*api.GetObjectAclResult, error) {
+	return api.GetObjectAcl(c, bucket, object)
+}
+
+// DeleteObjectAcl - delete the acl of the given object
+//
+// PARAMS:
+//     - bucket: the bucket name
+//     - object: the object name
+// RETURNS:
+//     - error: nil if success otherwise the specific error
+func (c *Client) DeleteObjectAcl(bucket, object string) error {
+	return api.DeleteObjectAcl(c, bucket, object)
+}

--- a/github.com/baidubce/bce-sdk-go/util/log/logger.go
+++ b/github.com/baidubce/bce-sdk-go/util/log/logger.go
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// logger.go - defines the logger structure and methods
+
+// Package log implements the log facilities for BCE. It supports log to stderr, stdout as well as
+// log to file with rotating. It is safe to be called by multiple goroutines.
+// By using the package level function to use the default logger:
+//     log.SetLogHandler(log.STDOUT | log.FILE) // default is log to stdout
+//     log.SetLogDir("/tmp")                    // default is /tmp
+//     log.SetRotateType(log.ROTATE_DAY)        // default is log.HOUR
+//     log.SetRotateSize(1 << 30)               // default is 1GB
+//     log.SetLogLevel(log.INFO)                // default is log.DEBUG
+//     log.Debug(1, 1.2, "a")
+//     log.Debugln(1, 1.2, "a")
+//     log.Debugf(1, 1.2, "a")
+// User can also create new logger without using the default logger:
+//     customLogger := log.NewLogger()
+//     customLogger.SetLogHandler(log.FILE)
+//     customLogger.Debug(1, 1.2, "a")
+// The log format can also support custom setting by using the following interface:
+//     log.SetLogFormat([]string{log.FMT_LEVEL, log.FMT_TIME, log.FMT_MSG})
+// Most of the cases just use the default format is enough:
+//     []string{FMT_LEVEL, FMT_LTIME, FMT_LOCATION, FMT_MSG}
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type Handler uint8
+
+// Constants for log handler flags, default is STDOUT
+const (
+	NONE   Handler = 0
+	STDOUT Handler = 1
+	STDERR Handler = 1 << 1
+	FILE   Handler = 1 << 2
+)
+
+type RotateStrategy uint8
+
+// Constants for log rotating strategy when logging to file, default is by hour
+const (
+	ROTATE_NONE RotateStrategy = iota
+	ROTATE_DAY
+	ROTATE_HOUR
+	ROTATE_MINUTE
+	ROTATE_SIZE
+
+	DEFAULT_ROTATE_TYPE           = ROTATE_HOUR
+	DEFAULT_ROTATE_SIZE     int64 = 1 << 30
+	DEFAULT_LOG_DIR               = "/tmp"
+	ROTATE_SIZE_FILE_PREFIX       = "rotating"
+)
+
+type Level uint8
+
+// Constants for log levels, default is DEBUG
+const (
+	DEBUG Level = iota
+	INFO
+	WARN
+	ERROR
+	FATAL
+	PANIC
+)
+
+var gLevelString = [...]string{"DEBUG", "INFO", "WARN", "ERROR", "FATAL", "PANIC"}
+
+// Constants of the log format components to support user custom specification
+const (
+	FMT_LEVEL    = "level"
+	FMT_LTIME    = "ltime"    // long time with microsecond
+	FMT_TIME     = "time"     // just with second
+	FMT_LOCATION = "location" // caller's location with file, line, function
+	FMT_MSG      = "msg"
+)
+
+var (
+	LOG_FMT_STR = map[string]string{
+		FMT_LEVEL:    "[%s]",
+		FMT_LTIME:    "2006-01-02 15:04:05.000000",
+		FMT_TIME:     "2006-01-02 15:04:05",
+		FMT_LOCATION: "%s:%d:%s:",
+		FMT_MSG:      "%s",
+	}
+	gDefaultLogFormat = []string{FMT_LEVEL, FMT_LTIME, FMT_LOCATION, FMT_MSG}
+)
+
+type writerArgs struct {
+	record     string
+	recordDone chan bool
+	rotateArgs interface{} // used for rotating: the size of the record or the logging time
+}
+
+// Logger defines the internal implementation of the log facility
+type logger struct {
+	writers        map[Handler]io.WriteCloser // the destination writer to log message
+	writerChan     chan *writerArgs           // the writer channal to pass each record and time or size
+	logFormat      []string
+	levelThreshold Level
+	handler        Handler
+
+	// Fields that used when logging to file
+	logDir     string
+	logFile    string
+	rotateType RotateStrategy
+	rotateSize int64
+}
+
+func (l *logger) logging(level Level, format string, args ...interface{}) {
+	// Only log message that set the handler and is greater than or equal to the threshold
+	if l.handler == NONE || level < l.levelThreshold {
+		return
+	}
+
+	// Generate the log record string and pass it to the writer channel
+	now := time.Now()
+	pc, file, line, ok, funcname := uintptr(0), "???", 0, true, "???"
+	pc, file, line, ok = runtime.Caller(2)
+	if ok {
+		funcname = runtime.FuncForPC(pc).Name()
+		funcname = filepath.Ext(funcname)
+		funcname = strings.TrimPrefix(funcname, ".")
+		file = filepath.Base(file)
+	}
+	buf := make([]string, 0, len(l.logFormat))
+	msg := fmt.Sprintf(format, args...)
+	for _, f := range l.logFormat {
+		if _, exists := LOG_FMT_STR[f]; !exists { // skip not supported part
+			continue
+		}
+		fmtStr := LOG_FMT_STR[f]
+		switch f {
+		case FMT_LEVEL:
+			buf = append(buf, fmt.Sprintf(fmtStr, gLevelString[level]))
+		case FMT_LTIME:
+			buf = append(buf, now.Format(fmtStr))
+		case FMT_TIME:
+			buf = append(buf, now.Format(fmtStr))
+		case FMT_LOCATION:
+			buf = append(buf, fmt.Sprintf(fmtStr, file, line, funcname))
+		case FMT_MSG:
+			buf = append(buf, fmt.Sprintf(fmtStr, msg))
+		}
+	}
+	record := strings.Join(buf, " ")
+	logRecordDone := make(chan bool)
+	if l.rotateType == ROTATE_SIZE {
+		l.writerChan <- &writerArgs{record, logRecordDone, int64(len(record))}
+	} else {
+		l.writerChan <- &writerArgs{record, logRecordDone, now}
+	}
+	<-logRecordDone // wait for current record done logging
+}
+
+func (l *logger) buildWriter(args interface{}) {
+	if l.handler&STDOUT == STDOUT {
+		l.writers[STDOUT] = os.Stdout
+	} else {
+		delete(l.writers, STDOUT)
+	}
+	if l.handler&STDERR == STDERR {
+		l.writers[STDERR] = os.Stderr
+	} else {
+		delete(l.writers, STDERR)
+	}
+	if l.handler&FILE == FILE {
+		l.writers[FILE] = l.buildFileWriter(args)
+	} else {
+		delete(l.writers, FILE)
+	}
+}
+
+func (l *logger) buildFileWriter(args interface{}) io.WriteCloser {
+	if l.handler&FILE != FILE {
+		return os.Stderr
+	}
+
+	if len(l.logDir) == 0 {
+		l.logDir = DEFAULT_LOG_DIR
+	}
+	if l.rotateType < ROTATE_NONE || l.rotateType > ROTATE_SIZE {
+		l.rotateType = DEFAULT_ROTATE_TYPE
+	}
+	if l.rotateType == ROTATE_SIZE && l.rotateSize == 0 {
+		l.rotateSize = DEFAULT_ROTATE_SIZE
+	}
+
+	logFile, needCreateFile := "", false
+	if l.rotateType == ROTATE_SIZE {
+		recordSize, _ := args.(int64)
+		logFile, needCreateFile = l.buildFileWriterBySize(recordSize)
+	} else {
+		recordTime, _ := args.(time.Time)
+		switch l.rotateType {
+		case ROTATE_NONE:
+			logFile = "default.log"
+		case ROTATE_DAY:
+			logFile = recordTime.Format("2006-01-02.log")
+		case ROTATE_HOUR:
+			logFile = recordTime.Format("2006-01-02_15.log")
+		case ROTATE_MINUTE:
+			logFile = recordTime.Format("2006-01-02_15-04.log")
+		}
+		if _, exist := getFileInfo(filepath.Join(l.logDir, logFile)); !exist {
+			needCreateFile = true
+		}
+	}
+	l.logFile = logFile
+	logFile = filepath.Join(l.logDir, l.logFile)
+
+	// Should create new file
+	if needCreateFile {
+		if w, ok := l.writers[FILE]; ok {
+			w.Close()
+		}
+		if writer, err := os.Create(logFile); err == nil {
+			return writer
+		} else {
+			return os.Stderr
+		}
+	}
+
+	// Already open the file
+	if w, ok := l.writers[FILE]; ok {
+		return w
+	}
+
+	// Newly open the file
+	if writer, err := os.OpenFile(logFile, os.O_WRONLY|os.O_APPEND, 0666); err == nil {
+		return writer
+	} else {
+		return os.Stderr
+	}
+}
+
+func (l *logger) buildFileWriterBySize(recordSize int64) (string, bool) {
+	logFile, needCreateFile := "", false
+	// First running the program and need to get filename by checking the existed files
+	if len(l.logFile) == 0 {
+		fname := fmt.Sprintf("%s-%s.0.log", ROTATE_SIZE_FILE_PREFIX, getSizeString(l.rotateSize))
+		for {
+			size, exist := getFileInfo(filepath.Join(l.logDir, fname))
+			if !exist {
+				logFile, needCreateFile = fname, true
+				break
+			}
+			if exist && size+recordSize <= l.rotateSize {
+				logFile, needCreateFile = fname, false
+				break
+			}
+			fname = getNextFileName(fname)
+		}
+	} else { // check the file size to append to the existed file or create a new file
+		currentFile := filepath.Join(l.logDir, l.logFile)
+		size, exist := getFileInfo(currentFile)
+		if !exist {
+			logFile, needCreateFile = l.logFile, true
+		} else {
+			if size+recordSize > l.rotateSize { // size exceeded
+				logFile, needCreateFile = getNextFileName(l.logFile), true
+			} else {
+				logFile, needCreateFile = l.logFile, false
+			}
+		}
+	}
+	return logFile, needCreateFile
+}
+
+func (l *logger) SetHandler(h Handler) { l.handler = h }
+
+func (l *logger) SetLogDir(dir string) { l.logDir = dir }
+
+func (l *logger) SetLogLevel(level Level) { l.levelThreshold = level }
+
+func (l *logger) SetLogFormat(format []string) { l.logFormat = format }
+
+func (l *logger) SetRotateType(rotate RotateStrategy) { l.rotateType = rotate }
+
+func (l *logger) SetRotateSize(size int64) { l.rotateSize = size }
+
+func (l *logger) Debug(msg ...interface{}) { l.logging(DEBUG, "%s\n", concat(msg...)) }
+
+func (l *logger) Debugln(msg ...interface{}) { l.logging(DEBUG, "%s\n", concat(msg...)) }
+
+func (l *logger) Debugf(f string, msg ...interface{}) { l.logging(DEBUG, f+"\n", msg...) }
+
+func (l *logger) Info(msg ...interface{}) { l.logging(INFO, "%s\n", concat(msg...)) }
+
+func (l *logger) Infoln(msg ...interface{}) { l.logging(INFO, "%s\n", concat(msg...)) }
+
+func (l *logger) Infof(f string, msg ...interface{}) { l.logging(INFO, f+"\n", msg...) }
+
+func (l *logger) Warn(msg ...interface{}) { l.logging(WARN, "%s\n", concat(msg...)) }
+
+func (l *logger) Warnln(msg ...interface{}) { l.logging(WARN, "%s\n", concat(msg...)) }
+
+func (l *logger) Warnf(f string, msg ...interface{}) { l.logging(WARN, f+"\n", msg...) }
+
+func (l *logger) Error(msg ...interface{}) { l.logging(ERROR, "%s\n", concat(msg...)) }
+
+func (l *logger) Errorln(msg ...interface{}) { l.logging(ERROR, "%s\n", concat(msg...)) }
+
+func (l *logger) Errorf(f string, msg ...interface{}) { l.logging(ERROR, f+"\n", msg...) }
+
+func (l *logger) Fatal(msg ...interface{}) { l.logging(FATAL, "%s\n", concat(msg...)) }
+
+func (l *logger) Fatalln(msg ...interface{}) { l.logging(FATAL, "%s\n", concat(msg...)) }
+
+func (l *logger) Fatalf(f string, msg ...interface{}) { l.logging(FATAL, f+"\n", msg...) }
+
+func (l *logger) Panic(msg ...interface{}) {
+	record := concat(msg...)
+	l.logging(PANIC, "%s\n", record)
+	panic(record)
+}
+
+func (l *logger) Panicln(msg ...interface{}) {
+	record := concat(msg...)
+	l.logging(PANIC, "%s\n", record)
+	panic(record)
+}
+
+func (l *logger) Panicf(format string, msg ...interface{}) {
+	record := fmt.Sprintf(format, msg)
+	l.logging(PANIC, format+"\n", msg...)
+	panic(record)
+}
+
+func NewLogger() *logger {
+	obj := &logger{
+		writers:        make(map[Handler]io.WriteCloser, 3), // now only support 3 kinds of handler
+		writerChan:     make(chan *writerArgs),
+		logFormat:      gDefaultLogFormat,
+		levelThreshold: DEBUG,
+		handler:        NONE,
+	}
+
+	// The backend writer goroutine to write each log record
+	go func() {
+		for {
+			select {
+			case args := <-obj.writerChan: // wait until a record comes to log
+				obj.buildWriter(args.rotateArgs)
+				for _, w := range obj.writers {
+					fmt.Fprint(w, args.record)
+				}
+				args.recordDone <- true
+			}
+		}
+	}()
+
+	return obj
+}

--- a/github.com/baidubce/bce-sdk-go/util/log/util.go
+++ b/github.com/baidubce/bce-sdk-go/util/log/util.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// util.go - define the package-level default logger and functions for easily use.
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// The global default logger object to perform logging in this package-level functions
+var gDefaultLogger *logger
+
+func init() {
+	gDefaultLogger = NewLogger()
+}
+
+// Helper functions
+func getFileInfo(path string) (int64, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return -1, false
+	} else {
+		return info.Size(), true
+	}
+}
+
+func getSizeString(size int64) string {
+	if size < 0 {
+		return fmt.Sprintf("%d", size)
+	}
+	if size < (1 << 10) {
+		return fmt.Sprintf("%dB", size)
+	} else if size < (1 << 20) {
+		return fmt.Sprintf("%dkB", size>>10)
+	} else if size < (1 << 30) {
+		return fmt.Sprintf("%dMB", size>>20)
+	} else if size < (1 << 40) {
+		return fmt.Sprintf("%dGB", size>>30)
+	} else {
+		return "SUPER-LARGE"
+	}
+}
+
+func getNextFileName(nowFileName string) string {
+	pos1 := strings.Index(nowFileName, ".")
+	rest := nowFileName[pos1+1:]
+	pos2 := strings.Index(rest, ".")
+	num, _ := strconv.Atoi(rest[0:pos2])
+	return fmt.Sprintf("%s.%d.log", nowFileName[0:pos1], num+1)
+}
+
+func concat(msg ...interface{}) string {
+	buf := make([]string, 0, len(msg))
+	for _, m := range msg {
+		buf = append(buf, fmt.Sprintf("%v", m))
+	}
+	return strings.Join(buf, " ")
+}
+
+// Export package-level functions for logging messages by using the default logger. It supports 3
+// kinds of interface which is similar to the standard package "fmt": with suffix of "ln", "f" or
+// nothing.
+func Debug(msg ...interface{}) {
+	gDefaultLogger.logging(DEBUG, "%s\n", concat(msg...))
+}
+
+func Debugln(msg ...interface{}) {
+	gDefaultLogger.logging(DEBUG, "%s\n", concat(msg...))
+}
+
+func Debugf(format string, msg ...interface{}) {
+	gDefaultLogger.logging(DEBUG, format+"\n", msg...)
+}
+
+func Info(msg ...interface{}) {
+	gDefaultLogger.logging(INFO, "%s\n", concat(msg...))
+}
+
+func Infoln(msg ...interface{}) {
+	gDefaultLogger.logging(INFO, "%s\n", concat(msg...))
+}
+
+func Infof(format string, msg ...interface{}) {
+	gDefaultLogger.logging(INFO, format+"\n", msg...)
+}
+
+func Warn(msg ...interface{}) {
+	gDefaultLogger.logging(WARN, "%s\n", concat(msg...))
+}
+
+func Warnln(msg ...interface{}) {
+	gDefaultLogger.logging(WARN, "%s\n", concat(msg...))
+}
+
+func Warnf(format string, msg ...interface{}) {
+	gDefaultLogger.logging(WARN, format+"\n", msg...)
+}
+
+func Error(msg ...interface{}) {
+	gDefaultLogger.logging(ERROR, "%s\n", concat(msg...))
+}
+
+func Errorln(msg ...interface{}) {
+	gDefaultLogger.logging(ERROR, "%s\n", concat(msg...))
+}
+
+func Errorf(format string, msg ...interface{}) {
+	gDefaultLogger.logging(ERROR, format+"\n", msg...)
+}
+
+func Fatal(msg ...interface{}) {
+	gDefaultLogger.logging(FATAL, "%s\n", concat(msg...))
+}
+
+func Fatalln(msg ...interface{}) {
+	gDefaultLogger.logging(FATAL, "%s\n", concat(msg...))
+}
+
+func Fatalf(format string, msg ...interface{}) {
+	gDefaultLogger.logging(FATAL, format+"\n", msg...)
+}
+
+func Panic(msg ...interface{}) {
+	record := concat(msg...)
+	gDefaultLogger.logging(PANIC, "%s\n", record)
+	panic(record)
+}
+
+func Panicln(msg ...interface{}) {
+	record := concat(msg...)
+	gDefaultLogger.logging(PANIC, "%s\n", record)
+	panic(record)
+}
+
+func Panicf(format string, msg ...interface{}) {
+	record := fmt.Sprintf(format, msg)
+	gDefaultLogger.logging(PANIC, format+"\n", msg...)
+	panic(record)
+}
+
+// SetLogHandler - set the handler of the logger
+//
+// PARAMS:
+//     - Handler: the handler defined in this package, now just support STDOUT, STDERR, FILE
+func SetLogHandler(h Handler) {
+	gDefaultLogger.handler = h
+}
+
+// SetLogLevel - set the level threshold of the logger, only level equal to or bigger than this
+// value will be logged.
+//
+// PARAMS:
+//     - Level: the level defined in this package, now support 6 levels.
+func SetLogLevel(l Level) {
+	gDefaultLogger.levelThreshold = l
+}
+
+// SetLogFormat - set the log component of each record when logging it. The default log format is
+// {FMT_LEVEL, FMT_LTIME, FMT_LOCATION, FMT_MSG}.
+//
+// PARAMS:
+//     - format: the format component array.
+func SetLogFormat(format []string) {
+	gDefaultLogger.logFormat = format
+}
+
+// SetLogDir - set the logging directory if logging to file.
+//
+// PARAMS:
+//     - dir: the logging directory
+// RETURNS:
+//     - error: check the directory and try to make it, otherwise return the error.
+func SetLogDir(dir string) error {
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			if mkErr := os.Mkdir(dir, 0644); mkErr != nil {
+				return mkErr
+			}
+		} else {
+			return err
+		}
+	}
+	gDefaultLogger.logDir = dir
+	return nil
+}
+
+// SetRotateType - set the rotating strategy if logging to file.
+//
+// PARAMS:
+//     - RotateStrategy: the rotate strategy defined in this package, now support 5 strategy.
+func SetRotateType(r RotateStrategy) {
+	gDefaultLogger.rotateType = r
+}
+
+// SetRotateSize - set the rotating size if logging to file and set the strategy of size.
+//
+// PARAMS:
+//     - size: the rotating size
+// RETURNS:
+//     - error: check the value and return any error if error occurs.
+func SetRotateSize(size int64) error {
+	if size <= 0 {
+		return fmt.Errorf("%s", "rotate size should not be negative")
+	}
+	gDefaultLogger.rotateSize = size
+	return nil
+}

--- a/github.com/baidubce/bce-sdk-go/util/string.go
+++ b/github.com/baidubce/bce-sdk-go/util/string.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// string.go - define the string util function
+
+// Package util defines the common utilities including string and time.
+package util
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+)
+
+func HmacSha256Hex(key, str_to_sign string) string {
+	hasher := hmac.New(sha256.New, []byte(key))
+	hasher.Write([]byte(str_to_sign))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func CalculateContentMD5(data io.Reader, size int64) (string, error) {
+	hasher := md5.New()
+	n, err := io.CopyN(hasher, data, size)
+	if err != nil {
+		return "", fmt.Errorf("calculate content-md5 occurs error: %v", err)
+	}
+	if n != size {
+		return "", fmt.Errorf("calculate content-md5 writing size %d != size %d", n, size)
+	}
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func UriEncode(uri string, encodeSlash bool) string {
+	var byte_buf bytes.Buffer
+	for _, b := range []byte(uri) {
+		if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') ||
+			b == '-' || b == '_' || b == '.' || b == '~' || (b == '/' && !encodeSlash) {
+			byte_buf.WriteByte(b)
+		} else {
+			byte_buf.WriteString(fmt.Sprintf("%%%02X", b))
+		}
+	}
+	return byte_buf.String()
+}
+
+func NewRequestId() string {
+	var buf [16]byte
+	for {
+		if _, err := rand.Read(buf[:]); err == nil {
+			break
+		}
+	}
+	buf[6] = (buf[6] & 0x0f) | (4 << 4)
+	buf[8] = (buf[8] & 0xbf) | 0x80
+
+	res := make([]byte, 36)
+	hex.Encode(res[0:8], buf[0:4])
+	res[8] = '-'
+	hex.Encode(res[9:13], buf[4:6])
+	res[13] = '-'
+	hex.Encode(res[14:18], buf[6:8])
+	res[18] = '-'
+	hex.Encode(res[19:23], buf[8:10])
+	res[23] = '-'
+	hex.Encode(res[24:], buf[10:])
+	return string(res)
+}

--- a/github.com/baidubce/bce-sdk-go/util/time.go
+++ b/github.com/baidubce/bce-sdk-go/util/time.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Baidu, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// time.go - define the time utility functions for BCE
+
+package util
+
+import "time"
+
+const (
+	RFC822Format  = "Mon, 02 Jan 2006 15:04:05 MST"
+	ISO8601Format = "2006-01-02T15:04:05Z"
+)
+
+func NowUTCSeconds() int64 { return time.Now().UTC().Unix() }
+
+func NowUTCNanoSeconds() int64 { return time.Now().UTC().UnixNano() }
+
+func FormatRFC822Date(timestamp_second int64) string {
+	tm := time.Unix(timestamp_second, 0).UTC()
+	return tm.Format(RFC822Format)
+}
+
+func ParseRFC822Date(time_string string) (time.Time, error) {
+	return time.Parse(RFC822Format, time_string)
+}
+
+func FormatISO8601Date(timestamp_second int64) string {
+	tm := time.Unix(timestamp_second, 0).UTC()
+	return tm.Format(ISO8601Format)
+}
+
+func ParseISO8601Date(time_string string) (time.Time, error) {
+	return time.Parse(ISO8601Format, time_string)
+}


### PR DESCRIPTION
I have did  as you say to adding a submodule ,"github.com/baidubce/bce-sdk-go", to vendor . It seems that this dependence must be accepted by "cockroachdb/vendored" before I push my code to cockroachdb/cockroach.

this is your words:
```
This change appears to be adding a submodule to vendor -- usually vendor is itself one, big submodule but itself usually just contains checked-in files, as arranged by the tool dep.

There are more docs here on how we manage vendored with dep:https://github.com/cockroachdb/cockroach/blob/2c79ad60cffc05100227fb07d4fbb307a755c08b/build/README.md#updating-dependencies

Basically, the short-answer is in export_storage.go, we'd add an import of github.com/baidubce/bce-sdk-go , then run ./bin/dep ensure and let it make the modifications in vendor, then commit those changes in the vendor that change would be what is in this PR.
```