### PR TITLE
arrow: set default memset for when the platform doesn't set one

### DIFF
--- a/github.com/apache/arrow/go/arrow/memory/memory.go
+++ b/github.com/apache/arrow/go/arrow/memory/memory.go
@@ -17,7 +17,7 @@
 package memory
 
 var (
-	memset func(b []byte, c byte)
+	memset func(b []byte, c byte) = memory_memset_go
 )
 
 // Set assigns the value c to every element of the slice buf.


### PR DESCRIPTION
Pulled the fix from apache/arrow commit # 89080e4.

On pcc64le platform, due to the missing default, the following
tests were failing with "panic:runtime error" due to SIGSEGV:
  pkg/sql/colexec:TestSupportedSQLTypesIntegration
  pkg/col/colserde:TestArrowBatchConverterRandom
  pkg/sql/logictest:TestLogic/fakedist/aggregate/other
Relevant part of the test failure log pasted below:
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x. addr=0x. pc=0x........]